### PR TITLE
Fix deeplinks tests

### DIFF
--- a/app/src/androidTest/java/social/entourage/android/DeeplinksTest.kt
+++ b/app/src/androidTest/java/social/entourage/android/DeeplinksTest.kt
@@ -185,7 +185,7 @@ class DeepLinkingTestEvents : DeepLinkingTest() {
     private fun connectedEventsDeeplink(uri: String) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
         startIntent(intent)
-        Espresso.onView(ViewMatchers.withText(R.string.map_tab_events)).check(ViewAssertions.matches(ViewMatchers.isSelected()))
+        Espresso.onView(ViewMatchers.withText(R.string.home_title_actions)).check(ViewAssertions.matches(ViewMatchers.isSelected()))
     }
 }
 
@@ -208,6 +208,7 @@ class DeepLinkingTestFeed : DeepLinkingTest() {
     private fun connectedFeedDeeplink(uri: String) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
         startIntent(intent)
+        Thread.sleep(1000) // We must wait for textview to appear
         Espresso.onView(ViewMatchers.withText(R.string.home_title_headlines)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
     }
 }

--- a/app/src/androidTest/java/social/entourage/android/DeeplinksTest.kt
+++ b/app/src/androidTest/java/social/entourage/android/DeeplinksTest.kt
@@ -4,9 +4,12 @@ import android.content.Intent
 import android.net.Uri
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.assertion.ViewAssertions
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers
 import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
+import org.hamcrest.core.AllOf.allOf
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -111,9 +114,12 @@ class DeepLinkingTestWebview : DeepLinkingTest() {
     }
 
     private fun connectedWebviewDeeplink(uri: String) {
+        Intents.init()
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
         startIntent(intent)
-        Espresso.onView(ViewMatchers.withId(R.id.webview_title)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        val expected = allOf(IntentMatchers.hasAction(Intent.ACTION_VIEW), IntentMatchers.hasData(uri))
+        Intents.intended(expected)
+        Intents.release()
     }
 
 }
@@ -165,6 +171,8 @@ class DeepLinkingTestFilters : DeepLinkingTest() {
     }
 }
 
+// TODO: Remove comment when tests pass
+// They should pass when new title text on another branch will be merged
 class DeepLinkingTestEvents : DeepLinkingTest() {
 
     @Test

--- a/app/src/androidTest/java/social/entourage/android/DeeplinksTest.kt
+++ b/app/src/androidTest/java/social/entourage/android/DeeplinksTest.kt
@@ -208,7 +208,7 @@ class DeepLinkingTestFeed : DeepLinkingTest() {
     private fun connectedFeedDeeplink(uri: String) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
         startIntent(intent)
-        Thread.sleep(1000) // We must wait for textview to appear
+        Thread.sleep(1000) // We must wait for view to appear (when we run all tests at once)
         Espresso.onView(ViewMatchers.withText(R.string.home_title_headlines)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
     }
 }
@@ -443,7 +443,8 @@ class DeepLinkingTestEntourage : DeepLinkingTest() {
     private fun connectedEntourageDeeplink(uri: String) {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
         startIntent(intent)
-        Espresso.onView(ViewMatchers.withId(R.id.entourage_info_title)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
+        Thread.sleep(1000) // We must wait for view to appear (when we run all tests at once)
+        Espresso.onView(ViewMatchers.withId(R.id.entourage_info_title_layout)).check(ViewAssertions.matches(ViewMatchers.isDisplayed()))
     }
 }
 

--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -212,9 +212,9 @@ class MainActivity : BaseSecuredActivity(),
             updateAnalyticsInfo()
         }
         refreshBadgeCount()
-        intent?.action?.let {
-            action ->
-            EntBus.post(OnCheckIntentActionEvent(action, intent.extras)) }
+        intent?.action?.let { action ->
+            EntBus.post(OnCheckIntentActionEvent(action, intent.extras))
+        }
       //  checkOnboarding()
     }
 

--- a/app/src/main/java/social/entourage/android/newsfeed/v2/ToursFragment.kt
+++ b/app/src/main/java/social/entourage/android/newsfeed/v2/ToursFragment.kt
@@ -33,7 +33,6 @@ import social.entourage.android.api.model.tour.TourType
 import social.entourage.android.api.tape.Events
 import social.entourage.android.api.tape.Events.*
 import social.entourage.android.base.BackPressable
-import social.entourage.android.service.EntService
 import social.entourage.android.location.EntLocation
 import social.entourage.android.location.LocationUtils
 import social.entourage.android.map.MapClusterEncounterItem
@@ -42,6 +41,7 @@ import social.entourage.android.map.filter.MapFilterFactory
 import social.entourage.android.map.filter.MapFilterFragment
 import social.entourage.android.newsfeed.NewsFeedFragment
 import social.entourage.android.newsfeed.NewsfeedTabItem
+import social.entourage.android.service.EntService
 import social.entourage.android.service.TourServiceListener
 import social.entourage.android.tools.log.AnalyticsEvents
 import social.entourage.android.tools.view.EntSnackbar
@@ -49,7 +49,6 @@ import social.entourage.android.tour.TourFilter
 import social.entourage.android.tour.TourFilterFragment
 import social.entourage.android.tour.confirmation.TourEndConfirmationFragment
 import social.entourage.android.tour.encounter.CreateEncounterActivity
-import timber.log.Timber
 import java.util.*
 
 open class ToursFragment : NewsFeedFragment(), TourServiceListener, BackPressable {

--- a/app/src/main/java/social/entourage/android/tools/view/WebViewFragment.kt
+++ b/app/src/main/java/social/entourage/android/tools/view/WebViewFragment.kt
@@ -1,7 +1,6 @@
 package social.entourage.android.tools.view
 
 import android.annotation.TargetApi
-import android.app.PendingIntent
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -29,7 +28,6 @@ import androidx.browser.customtabs.CustomTabsIntent.SHARE_STATE_ON
 import androidx.browser.customtabs.CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION
 import androidx.core.view.GestureDetectorCompat
 import kotlinx.android.synthetic.main.fragment_webview.*
-import social.entourage.android.MainActivity
 import social.entourage.android.R
 import social.entourage.android.base.BaseDialogFragment
 import java.util.*

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -142,7 +142,6 @@ ext {
                             group: "com.squareup.okhttp3"
                     ]
             ],
-            //rules           : "com.android.support.test:rules:1.0.2",
             testJunit       : "androidx.test.ext:junit:1.1.2",
             testRunner      : "androidx.test:runner:1.3.0",
             testRules       : "androidx.test:rules:1.3.0"


### PR DESCRIPTION
[Ticket](https://entourage-asso.atlassian.net/browse/EN-3667)

- Fix DeepLinkingTestWebview: in fact webviews are no more used, we use browser tab instead
- Fix DeepLinkingTestEvents: check title text (tests dont pass now because this text will be uptaded by another branch)
- Fix DeepLinkingTestEntourage: check title layout instead of textview because it is not always displayed

NB: Delays (Thread.sleep) have been added to allow running blocks of tests at once. Tests all pass individually but may need delay to pass in a suite