### PR TITLE
Add 3 new bitrise workflows

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -208,6 +208,13 @@ workflows:
             - gradle_options: --stacktrace
             - gradle_task: connectedAndroidTest
   testui_virtualdevice_entourage:
+    envs:
+      - GRADLE_TASK: assembleDebug
+        opts:
+          is_expand: false
+      - GRADLE_TEST_TASK: assembleAndroidTest
+        opts:
+          is_expand: false
     steps:
       - install-missing-android-tools: { }
       # Choose the right build step
@@ -215,13 +222,13 @@ workflows:
 #            - android-build@0:
 #                inputs:
 #                  - variant: EntourageStagingDebugAndroidTest
-#            - gradle-runner@1:
-#                inputs:
-#                  - gradle_task: assembleDebug assembleAndroidTest #Should be assembleDebug assembleDebugAndroidTest
-      - android-build-for-ui-testing@0:
+      - gradle-runner:
+          inputs:
+            - gradle_task: $GRADLE_TASK $GRADLE_TEST_TASK #Should be assembleDebug assembleDebugAndroidTest
+      - android-build-for-ui-testing:
           inputs:
             - variant: entourageStagingDebug
             - module: app
-      - virtual-device-testing-for-android@1:
+      - virtual-device-testing-for-android:
           inputs:
             - test_type: instrumentation

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -179,3 +179,49 @@ workflows:
     - git-tag:
         inputs:
         - tag: Version_$BITRISE_BUILD_NUMBER
+  linter_entourage:
+    steps:
+      - install-missing-android-tools: { }
+      - gradle-runner:
+          inputs:
+            - apk_file_include_filter: ""
+            - app_file_include_filter: '*.apk'
+            - gradle_task: assembleDebug
+            - gradle_options: --stacktrace
+      - android-lint@0: { }
+  testui_emulator_entourage:
+    steps:
+      # Needed if you updated AndroidStudio which uses Java 11
+#      - script@1:
+#          inputs:
+#            - content: |-
+#                jenv global 11
+#                export JAVA_HOME="$(jenv prefix)"
+#                envman add --key JAVA_HOME --value "$(jenv prefix)"
+      - avd-manager@1: {}
+      - install-missing-android-tools: {}
+      - wait-for-android-emulator@1: {}
+      - gradle-runner:
+          inputs:
+            - apk_file_include_filter: ""
+            - app_file_include_filter: '*.apk'
+            - gradle_options: --stacktrace
+            - gradle_task: connectedAndroidTest
+  testui_virtualdevice_entourage:
+    steps:
+      - install-missing-android-tools: { }
+      # Choose the right build step
+#       virtual-device-testing-for-android step wont launch locally
+#            - android-build@0:
+#                inputs:
+#                  - variant: EntourageStagingDebugAndroidTest
+#            - gradle-runner@1:
+#                inputs:
+#                  - gradle_task: assembleDebug assembleAndroidTest #Should be assembleDebug assembleDebugAndroidTest
+      - android-build-for-ui-testing@0:
+          inputs:
+            - variant: entourageStagingDebug
+            - module: app
+      - virtual-device-testing-for-android@1:
+          inputs:
+            - test_type: instrumentation


### PR DESCRIPTION
[Ticket](https://entourage-asso.atlassian.net/browse/EN-3750)

Need to be tested on real online Bitrise

On Bitrise CLI:
- `linter_entourage` works well
- `testui_emulator_entourage` has sometimes troubles with `DeeplinksTest` (may be fixed but I have issues running it since last Android Studio update...)
- `testui_virtualdevice_entourage` may need to be run online

Useful links:
[Bitrise instrumentation tests](https://devcenter.bitrise.io/testing/device-testing-for-android/#running-instrumentation-tests
)
[Medium article about Bitrise tests](https://medium.com/@bitrise/from-zero-to-testing-an-android-app-on-bitrise-part-2-of-2-2ecb660155ba)
[Bitrise topic about missing app_slug parameter for virtualdevice step](https://discuss.bitrise.io/t/how-can-i-get-an-app-slug/4624/4)