### PR TITLE
fix: EN-8556 prevent crash on autocomplete suggestions (EditProfileAc…

### DIFF
--- a/app/src/main/java/social/entourage/android/profile/EditProfileActivity.kt
+++ b/app/src/main/java/social/entourage/android/profile/EditProfileActivity.kt
@@ -364,13 +364,15 @@ class EditProfileActivity : BaseActivity(), AvatarUploadView {
     }
 
     private fun updateAutocompleteSuggestions(suggestions: List<String>) {
-        autocompleteAdapter?.clear()
-        autocompleteAdapter?.addAll(suggestions)
-        autocompleteAdapter?.notifyDataSetChanged()
+        if (!isFinishing && !isDestroyed) {
+            autocompleteAdapter?.clear()
+            autocompleteAdapter?.addAll(suggestions)
+            autocompleteAdapter?.notifyDataSetChanged()
 
-        // Montre le menu déroulant SEULEMENT si le champ a encore le focus
-        if (binding.cityAction.hasFocus()) {
-            binding.cityAction.showDropDown()
+            // Montre le menu déroulant SEULEMENT si le champ a encore le focus
+            if (binding.cityAction.hasFocus()) {
+                binding.cityAction.showDropDown()
+            }
         }
     }
 


### PR DESCRIPTION
…tivity)

Wrapped the autocomplete update logic in a check for `!isFinishing && !isDestroyed` to prevent a crash when the activity is closing while suggestions are being updated.