### PR TITLE
Rename 'Ambassadeur' to 'Animateur Entourage' and optimize role display

### DIFF
--- a/app/src/main/java/social/entourage/android/api/model/EntourageUser.kt
+++ b/app/src/main/java/social/entourage/android/api/model/EntourageUser.kt
@@ -108,11 +108,28 @@ class EntourageUser : TimestampedObject(), Serializable {
             }
 
             for (role in roles) {
-                if(roleStr.isNotEmpty()) {
-                    roleStr = "$roleStr • $role"
+                var displayRole = role
+                if (role == "Ambassadeur" || role.equals("ambassador", ignoreCase = true)) {
+                    displayRole = "Animateur Entourage"
+                } else if (role == "Équipe Entourage") {
+                    if (partner != null) {
+                        displayRole = ""
+                    } else {
+                        displayRole = "Équipe"
+                    }
+                } else if (role == "Association") {
+                    if (partner != null) {
+                        displayRole = ""
+                    }
                 }
-                else {
-                    roleStr = role
+
+                if (displayRole.isNotEmpty()) {
+                    if(roleStr.isNotEmpty()) {
+                        roleStr = "$roleStr • $displayRole"
+                    }
+                    else {
+                        roleStr = displayRole
+                    }
                 }
 
                 break //TODO: why do we get only the first role ?

--- a/app/src/main/res/values-any/strings.xml
+++ b/app/src/main/res/values-any/strings.xml
@@ -69,7 +69,7 @@
     <string name="home_help_button_1">Faire un don financier à\nEntourage</string>
     <string name="home_help_button_2">Devenir reporter pour\nEntourage</string>
     <string name="home_help_button_3">Parler d’Entourage</string>
-    <string name="home_help_button_4">Devenir Ambassadeur</string>
+    <string name="home_help_button_4">Devenir Animateur Entourage</string>
     <string name="home_help_button_5">Programme LinkedOut</string>
     <string name="home_button_help_title">J’aide Entourage autrement</string>
     <string name="home_button_change_zone">Je modifie ma zone d’action</string>
@@ -157,7 +157,7 @@ Découvrez les initiatives de votre quartier et tissez des liens avec vos voisin
     <string name="edit_interests">Modifier mes centres d’interêt</string>
     <string name="follow">S\'abonner</string>
     <string name="following">Abonné</string>
-    <string name="ambassador">Ambassadeur</string>
+    <string name="ambassador">Animateur Entourage</string>
 
     <string name="group_name">Nom du groupe</string>
     <string name="event_name">Nom de l\'événement</string>
@@ -1802,7 +1802,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="menu_info_first_guide">Notre guide pour oser la rencontre</string>
     <string name="menu_info_second_gift">Faire un don à Entourage</string>
     <string name="menu_info_second_help">Aider à la réinsertion</string>
-    <string name="menu_info_second_ambassador">Devenir Ambassadeur bénévole</string>
+    <string name="menu_info_second_ambassador">Devenir Animateur Entourage bénévole</string>
     <string name="menu_info_second_good">Créer des liens avec les Bonnes Ondes</string>
     <string name="menu_info_second_title">❤️  S’ENGAGER</string>
     <string name="menu_info_third_info">Comment en parler aux personnes isolées ?</string>
@@ -2050,8 +2050,8 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="partner_remove_ok">Badge enlevé</string>
 
     <string name="member_type_organization">Maraudeur</string>
-    <string name="role_ambassador">Ambassadeur</string>
-    <string name="role_admin">Ambassadeur</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
 
     <string name="market_url">market://details?id=%s</string>
     <string name="playstore_url">https://play.google.com/store/apps/details?id=%s</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -67,7 +67,7 @@
     <string name="home_help_description">إليك كيفية المشاركة في مشروع Entourage، إذا لم تكن هناك أحداث أو أنشطة في منطقتك:</string>
     <string name="home_help_button_1">قم بالتبرع المالي إلى \nEntourage</string>
     <string name="home_help_button_3">الحديث عن حاشية</string>
-    <string name="home_help_button_4">كن سفيرا</string>
+    <string name="home_help_button_4">كن Animateur Entourage</string>
     <string name="home_help_button_5">برنامج لينكد اوت</string>
     <string name="home_button_help_title">أنا أساعد Entourage بطريقة مختلفة</string>
     <string name="home_button_change_zone">أقوم بتعديل مجال عملي</string>
@@ -152,7 +152,7 @@
     <string name="edit_interests">تغيير اهتماماتي</string>
     <string name="follow">S\الاشتراك</string>
     <string name="following">المشترك</string>
-    <string name="ambassador">سفير</string>
+    <string name="ambassador">Animateur Entourage</string>
 
     <string name="group_name">اسم المجموعة</string>
     <string name="event_name">اسم الحدث \</string>
@@ -1764,7 +1764,7 @@
     <string name="menu_info_first_guide">دليلنا للجرأة للقاء</string>
     <string name="menu_info_second_gift">تبرع للحاشية</string>
     <string name="menu_info_second_help">المساعدة في إعادة الإدماج</string>
-    <string name="menu_info_second_ambassador">كن سفيرًا متطوعًا</string>
+    <string name="menu_info_second_ambassador">كن Animateur Entourage متطوعًا</string>
     <string name="menu_info_second_good">إنشاء روابط مع Good Waves</string>
     <string name="menu_info_second_title">❤️ شارك</string>
     <string name="menu_info_third_info">كيف تتحدث مع الأشخاص المعزولين عن ذلك؟</string>
@@ -2029,8 +2029,8 @@
     <string name="partner_remove_ok">تمت إزالة الشارة</string>
 
     <string name="member_type_organization">اللص</string>
-    <string name="role_ambassador">سفير</string>
-    <string name="role_admin">سفير</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
 
     <string name="user_profile_display_title">حساب تعريفي</string>
     <string name="user_button_confirm_changes">أكد</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -69,7 +69,7 @@
     <string name="home_help_button_1">Machen Sie eine finanzielle Spende an \nEntourage</string>
     <string name="home_help_button_2">Devenir reporter pour\nEntourage</string>
     <string name="home_help_button_3">Sprechen Sie über Entourage</string>
-    <string name="home_help_button_4">Werden Sie Botschafter</string>
+    <string name="home_help_button_4">Werden Sie Animateur Entourage</string>
     <string name="home_help_button_5">LinkedOut-Programm</string>
     <string name="home_button_help_title">Ich helfe Entourage auf eine andere Art und Weise</string>
     <string name="home_button_change_zone">Ich ändere meinen Wirkungsbereich</string>
@@ -157,7 +157,7 @@ Entdecken Sie Initiativen in Ihrer Nachbarschaft und bauen Sie Kontakte zu Ihren
     <string name="edit_interests">Ändere meine Interessen</string>
     <string name="follow">S\abonnieren</string>
     <string name="following">Teilnehmer</string>
-    <string name="ambassador">Botschafter</string>
+    <string name="ambassador">Animateur Entourage</string>
 
     <string name="group_name">Name der Gruppe</string>
     <string name="event_name">Ereignisname</string>
@@ -1785,7 +1785,7 @@ Sie werden diese Nachricht lesen, sobald sie der Gruppe beitreten.</string>
     <string name="menu_info_first_guide">Unser Leitfaden für den Mut, sich zu treffen</string>
     <string name="menu_info_second_gift">Spenden Sie an Entourage</string>
     <string name="menu_info_second_help">Hilfe bei der Wiedereingliederung</string>
-    <string name="menu_info_second_ambassador">Werden Sie ehrenamtlicher Botschafter</string>
+    <string name="menu_info_second_ambassador">Werden Sie ehrenamtlicher Animateur Entourage</string>
     <string name="menu_info_second_good">Erstellen Sie Links mit Good Waves</string>
     <string name="menu_info_second_title">❤️ Beteiligen Sie sich</string>
     <string name="menu_info_third_info">Wie kann man mit isolierten Menschen darüber sprechen?</string>
@@ -2032,8 +2032,8 @@ Sie werden diese Nachricht lesen, sobald sie der Gruppe beitreten.</string>
     <string name="partner_remove_ok">Abzeichen entfernt</string>
 
     <string name="member_type_organization">Rumtreiber</string>
-    <string name="role_ambassador">Botschafter</string>
-    <string name="role_admin">Botschafter</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
 
     <string name="user_profile_display_title">PROFIL</string>
     <string name="user_button_confirm_changes">Bestätigen</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -56,7 +56,7 @@
     <string name="home_help_button_1">Make a financial donation to Entourage</string>
     <string name="home_help_button_2">Become a reporter for\nEntourage</string>
     <string name="home_help_button_3">Talk about Entourage</string>
-    <string name="home_help_button_4">Become an Ambassador</string>
+    <string name="home_help_button_4">Become an Animateur Entourage</string>
     <string name="home_help_button_5">LinkedOut program</string>
     <string name="home_button_help_title">I help Entourage in a different way</string>
     <string name="home_button_change_zone">I change my action zone</string>
@@ -135,7 +135,7 @@
     <string name="edit_interests">Edit my hobbies</string>
     <string name="follow">Subscribe</string>
     <string name="following">Subscriber</string>
-    <string name="ambassador">Ambassador</string>
+    <string name="ambassador">Animateur Entourage</string>
     <string name="group_name">Group name</string>
     <string name="event_name">Event name</string>
     <string name="group_name_hint">Neighbors in Paris 18</string>
@@ -1002,7 +1002,7 @@
     <string name="menu_info_first_guide">Our guide to daring to meet</string>
     <string name="menu_info_second_gift">Donate to Entourage</string>
     <string name="menu_info_second_help">Help with reintegration</string>
-    <string name="menu_info_second_ambassador">Become a Volunteer Ambassador</string>
+    <string name="menu_info_second_ambassador">Become a Volunteer Animateur Entourage</string>
     <string name="menu_info_second_good">Create links with Good Waves</string>
     <string name="menu_info_second_title">❤️ GET INVOLVED</string>
     <string name="menu_info_third_info">How to talk to isolated people about it?</string>
@@ -1203,8 +1203,8 @@
     <string name="partner_add_ok">Badge added</string>
     <string name="partner_remove_ok">Badge removed</string>
     <string name="member_type_organization">Marauder</string>
-    <string name="role_ambassador">Ambassador</string>
-    <string name="role_admin">Ambassador</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
     <string name="user_profile_display_title">Profile</string>
     <string name="user_button_confirm_changes">Confirm</string>
     <string name="user_text_update_ok">Profile updated</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -71,7 +71,7 @@
     <string name="home_help_button_1">Haga una donación financiera a\nEntourage</string>
     <string name="home_help_button_2">Devenir reporter pour\nEntourage</string>
     <string name="home_help_button_3">Hablar de séquito</string>
-    <string name="home_help_button_4">Conviértete en embajador</string>
+    <string name="home_help_button_4">Conviértete en Animateur Entourage</string>
     <string name="home_help_button_5">Programa LinkedOut</string>
     <string name="home_button_help_title">Ayudo a Entourage de una manera diferente</string>
     <string name="home_button_change_zone">Modifico mi área de acción</string>
@@ -159,7 +159,7 @@ Descubra iniciativas en su vecindario y establezca conexiones con sus vecinos.</
     <string name="edit_interests">cambiar mis intereses</string>
     <string name="follow">S\subscribirse</string>
     <string name="following">Abonado</string>
-    <string name="ambassador">Embajador</string>
+    <string name="ambassador">Animateur Entourage</string>
 
     <string name="group_name">Nombre del grupo</string>
     <string name="event_name">Nombre del evento \</string>
@@ -1785,7 +1785,7 @@ Leerán este mensaje tan pronto como se unan al grupo.</string>
     <string name="menu_info_first_guide">Nuestra guía para atreverse a encontrarse</string>
     <string name="menu_info_second_gift">Donar a Entourage</string>
     <string name="menu_info_second_help">Ayuda con la reintegración</string>
-    <string name="menu_info_second_ambassador">Conviértete en Embajador Voluntario</string>
+    <string name="menu_info_second_ambassador">Conviértete en Animateur Entourage Voluntario</string>
     <string name="menu_info_second_good">Crea vínculos con Buenas Ondas</string>
     <string name="menu_info_second_title">❤️ PARTICIPA</string>
     <string name="menu_info_third_info">¿Cómo hablar de esto con personas aisladas?</string>
@@ -2032,8 +2032,8 @@ Leerán este mensaje tan pronto como se unan al grupo.</string>
     <string name="partner_remove_ok">Insignia eliminada</string>
 
     <string name="member_type_organization">Merodeador</string>
-    <string name="role_ambassador">Embajador</string>
-    <string name="role_admin">Embajador</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
 
     <string name="user_profile_display_title">PERFIL</string>
     <string name="user_button_confirm_changes">Confirmar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -68,7 +68,7 @@
     <string name="home_help_button_1">Faire un don financier à\nEntourage</string>
     <string name="home_help_button_2">Devenir reporter pour\nEntourage</string>
     <string name="home_help_button_3">Parler d’Entourage</string>
-    <string name="home_help_button_4">Devenir Ambassadeur</string>
+    <string name="home_help_button_4">Devenir Animateur Entourage</string>
     <string name="home_help_button_5">Programme LinkedOut</string>
     <string name="home_button_help_title">J’aide Entourage autrement</string>
     <string name="home_button_change_zone">Je modifie ma zone d’action</string>
@@ -156,7 +156,7 @@ Découvrez les initiatives de votre quartier et tissez des liens avec vos voisin
     <string name="edit_interests">Modifier mes centres d’interêt</string>
     <string name="follow">S\'abonner</string>
     <string name="following">Abonné</string>
-    <string name="ambassador">Ambassadeur</string>
+    <string name="ambassador">Animateur Entourage</string>
 
     <string name="group_name">Nom du groupe</string>
     <string name="event_name">Nom de l\'événement</string>
@@ -1813,7 +1813,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="menu_info_first_guide">Notre guide pour oser la rencontre</string>
     <string name="menu_info_second_gift">Faire un don à Entourage</string>
     <string name="menu_info_second_help">Aider à la réinsertion</string>
-    <string name="menu_info_second_ambassador">Devenir Ambassadeur bénévole</string>
+    <string name="menu_info_second_ambassador">Devenir Animateur Entourage bénévole</string>
     <string name="menu_info_second_good">Créer des liens avec les Bonnes Ondes</string>
     <string name="menu_info_second_title">❤️  S’ENGAGER</string>
     <string name="menu_info_third_info">Comment en parler aux personnes isolées ?</string>
@@ -2060,8 +2060,8 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="partner_remove_ok">Badge enlevé</string>
 
     <string name="member_type_organization">Maraudeur</string>
-    <string name="role_ambassador">Ambassadeur</string>
-    <string name="role_admin">Ambassadeur</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
 
     <string name="user_profile_display_title">PROFIL</string>
     <string name="user_button_confirm_changes">Confirmer</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -71,7 +71,7 @@
     <string name="home_help_button_1">Przekaż darowiznę finansową na rzecz \nEntourage</string>
     <string name="home_help_button_2">Devenir reporter pour\nEntourage</string>
     <string name="home_help_button_3">Porozmawiaj o Entourage</string>
-    <string name="home_help_button_4">Zostań Ambasadorem</string>
+    <string name="home_help_button_4">Zostań Animateur Entourage</string>
     <string name="home_help_button_5">programu LinkedOut</string>
     <string name="home_button_help_title">Pomagam Entourage w inny sposób</string>
     <string name="home_button_change_zone">Modyfikuję swój obszar działania</string>
@@ -159,7 +159,7 @@ Odkrywaj inicjatywy w swojej okolicy i buduj kontakty z sąsiadami.</string>
     <string name="edit_interests">Zmień moje zainteresowania</string>
     <string name="follow">S\subskrybuj</string>
     <string name="following">Abonent</string>
-    <string name="ambassador">Ambasador</string>
+    <string name="ambassador">Animateur Entourage</string>
 
     <string name="group_name">Nazwa grupy</string>
     <string name="event_name">Nazwa wydarzenia \</string>
@@ -1782,7 +1782,7 @@ Przeczytają tę wiadomość, gdy tylko dołączą do grupy.</string>
     <string name="menu_info_first_guide">Nasz przewodnik po odważeniu się na spotkanie</string>
     <string name="menu_info_second_gift">Przekaż darowiznę na rzecz Entourage</string>
     <string name="menu_info_second_help">Pomoc w reintegracji</string>
-    <string name="menu_info_second_ambassador">Zostań Ambasadorem Wolontariatu</string>
+    <string name="menu_info_second_ambassador">Zostań Animateur Entourage Wolontariatu</string>
     <string name="menu_info_second_good">Twórz połączenia z Good Waves</string>
     <string name="menu_info_second_title">❤️ ZAANGAŻUJ SIĘ</string>
     <string name="menu_info_third_info">Jak rozmawiać o tym z izolowanymi ludźmi?</string>
@@ -2043,8 +2043,8 @@ Przeczytają tę wiadomość, gdy tylko dołączą do grupy.</string>
     <string name="partner_remove_ok">Odznaka usunięta</string>
 
     <string name="member_type_organization">Maruder</string>
-    <string name="role_ambassador">Ambasador</string>
-    <string name="role_admin">Ambasador</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
 
     <string name="user_profile_display_title">PROFIL</string>
     <string name="user_button_confirm_changes">Potwierdzać</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -71,7 +71,7 @@
     <string name="home_help_button_1">Fă o donație financiară către \nEntourage</string>
     <string name="home_help_button_2">Devenir reporter pour\nEntourage</string>
     <string name="home_help_button_3">Vorbiți despre Entourage</string>
-    <string name="home_help_button_4">Deveniți ambasador</string>
+    <string name="home_help_button_4">Deveniți Animateur Entourage</string>
     <string name="home_help_button_5">Programul LinkedOut</string>
     <string name="home_button_help_title">Ajut Entourage într-un mod diferit</string>
     <string name="home_button_change_zone">Îmi modific aria de acțiune</string>
@@ -159,7 +159,7 @@ Descoperiți inițiativele din cartierul dvs. și construiți legături cu vecin
     <string name="edit_interests">Schimbă-mi interesele</string>
     <string name="follow">S\abonați-vă</string>
     <string name="following">Abonat</string>
-    <string name="ambassador">Ambasador</string>
+    <string name="ambassador">Animateur Entourage</string>
 
     <string name="group_name">Numele grupului</string>
     <string name="event_name">Numele evenimentului \</string>
@@ -1784,7 +1784,7 @@ Ei vor citi acest mesaj imediat ce se vor alătura grupului.</string>
     <string name="menu_info_first_guide">Ghidul nostru pentru a îndrăzni să ne întâlnim</string>
     <string name="menu_info_second_gift">Donează către Entourage</string>
     <string name="menu_info_second_help">Ajutor la reintegrare</string>
-    <string name="menu_info_second_ambassador">Deveniți un ambasador voluntar</string>
+    <string name="menu_info_second_ambassador">Deveniți un Animateur Entourage voluntar</string>
     <string name="menu_info_second_good">Creați legături cu Good Waves</string>
     <string name="menu_info_second_title">❤️ IMPLICAȚI-VĂ</string>
     <string name="menu_info_third_info">Cum să vorbești cu oameni izolați despre asta?</string>
@@ -2040,8 +2040,8 @@ Ei vor citi acest mesaj imediat ce se vor alătura grupului.</string>
     <string name="partner_remove_ok">Insigna eliminată</string>
 
     <string name="member_type_organization">Jefuitor</string>
-    <string name="role_ambassador">Ambasador</string>
-    <string name="role_admin">Ambasador</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
 
     <string name="user_profile_display_title">PROFIL</string>
     <string name="user_button_confirm_changes">A confirma</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -71,7 +71,7 @@
     <string name="home_help_button_1">Зробіть фінансову пожертву \nEntourage</string>
     <string name="home_help_button_2">Devenir reporter pour\nEntourage</string>
     <string name="home_help_button_3">Розмова про Entourage</string>
-    <string name="home_help_button_4">Стань амбасадором</string>
+    <string name="home_help_button_4">Стань Animateur Entourage</string>
     <string name="home_help_button_5">Програма LinkedOut</string>
     <string name="home_button_help_title">Я допомагаю Entourage іншим способом</string>
     <string name="home_button_change_zone">Я зміню свою сферу діяльності</string>
@@ -159,7 +159,7 @@
     <string name="edit_interests">Змінити мої інтереси</string>
     <string name="follow">S\підписатися</string>
     <string name="following">Абонент</string>
-    <string name="ambassador">посол</string>
+    <string name="ambassador">Animateur Entourage</string>
 
     <string name="group_name">Назва групи</string>
     <string name="event_name">Назва події \</string>
@@ -1787,7 +1787,7 @@
     <string name="menu_info_first_guide">Наш посібник, як наважитися на зустріч</string>
     <string name="menu_info_second_gift">Пожертвуйте Entourage</string>
     <string name="menu_info_second_help">Допомога з реінтеграцією</string>
-    <string name="menu_info_second_ambassador">Стань волонтерським амбасадором</string>
+    <string name="menu_info_second_ambassador">Стань волонтерським Animateur Entourage</string>
     <string name="menu_info_second_good">Створюйте посилання з Good Waves</string>
     <string name="menu_info_second_title">❤️ ПРИЄДНУЙТЕСЯ</string>
     <string name="menu_info_third_info">Як поговорити про це з ізольованими людьми?</string>
@@ -2046,8 +2046,8 @@
     <string name="partner_remove_ok">Бейдж видалено</string>
 
     <string name="member_type_organization">Мародер</string>
-    <string name="role_ambassador">посол</string>
-    <string name="role_admin">посол</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
 
     <string name="user_profile_display_title">ПРОФІЛЬ</string>
     <string name="user_button_confirm_changes">Підтвердити</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,7 +71,7 @@
     <string name="home_help_button_1">Faire un don financier à\nEntourage</string>
     <string name="home_help_button_2">Devenir reporter pour\nEntourage</string>
     <string name="home_help_button_3">Parler d’Entourage</string>
-    <string name="home_help_button_4">Devenir Ambassadeur</string>
+    <string name="home_help_button_4">Devenir Animateur Entourage</string>
     <string name="home_help_button_5">Programme LinkedOut</string>
     <string name="home_button_help_title">J’aide Entourage autrement</string>
     <string name="home_button_change_zone">Je modifie ma zone d’action</string>
@@ -160,7 +160,7 @@ Découvrez les initiatives de votre quartier et tissez des liens avec vos voisin
     <string name="edit_interests">Modifier mes centres d’interêts</string>
     <string name="follow">S\'abonner</string>
     <string name="following">Abonné</string>
-    <string name="ambassador">Ambassadeur</string>
+    <string name="ambassador">Animateur Entourage</string>
 
     <string name="group_name">Nom du groupe</string>
     <string name="event_name">Nom de l\'événement</string>
@@ -2010,7 +2010,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="menu_info_first_guide">Notre guide pour oser la rencontre</string>
     <string name="menu_info_second_gift">Faire un don à Entourage</string>
     <string name="menu_info_second_help">Aider à la réinsertion</string>
-    <string name="menu_info_second_ambassador">Devenir Ambassadeur bénévole</string>
+    <string name="menu_info_second_ambassador">Devenir Animateur Entourage bénévole</string>
     <string name="menu_info_second_good">Créer des liens avec les Bonnes Ondes</string>
     <string name="menu_info_second_title">❤️  S’ENGAGER</string>
     <string name="menu_info_third_info">Comment en parler aux personnes isolées ?</string>
@@ -2252,8 +2252,8 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="partner_remove_ok">Badge enlevé</string>
 
     <string name="member_type_organization">Maraudeur</string>
-    <string name="role_ambassador">Ambassadeur</string>
-    <string name="role_admin">Ambassadeur</string>
+    <string name="role_ambassador">Animateur Entourage</string>
+    <string name="role_admin">Animateur Entourage</string>
     <string name="disclaimer_link_public" translatable="false">https://www.entourage.social/blog/charte-ethique-entourage-local</string>
     <string name="ambassadeur_link_public" translatable="false">https://www.entourage.social/agir-avec-nous/par-action/devenir-benevole</string>
     <string name="faq_link_public" translatable="false">https://www.entourage.social/blog/lantiseche-tout-savoir-pour-bien-commencer-sur-lapp-entourage</string>


### PR DESCRIPTION
This change updates the display logic for user roles in lists (e.g., Members list).
It renames "Ambassadeur" to "Animateur Entourage" globally.
It also simplifies the display for "Association" and "Équipe Entourage" roles by prioritizing the Partner Name if available, avoiding redundancy like "Équipe Entourage - Entourage Rennes".

---
*PR created automatically by Jules for task [15475811839408042413](https://jules.google.com/task/15475811839408042413) started by @clemPerrousset*