### PR TITLE
Handle birthday notification redirection to Home and Birthday view

### DIFF
--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -228,6 +228,13 @@ class MainActivity : BaseSecuredActivity() {
             shouldLaunchProfile = false
             showProfile()
         }
+
+        // 7. Lancement de la vue anniversaire
+        if (shouldLaunchBirthday) {
+            shouldLaunchBirthday = false
+            goHome()
+            startActivity(Intent(this, social.entourage.android.home.BirthdayActivity::class.java))
+        }
     }
 
     private fun checkForAppUpdate() {
@@ -387,11 +394,12 @@ class MainActivity : BaseSecuredActivity() {
                 rawContent,
                 PushNotificationContent::class.java
             )?.extra?.let { extra ->
-                extra.instance?.let { instance ->
+                val instance = extra.instance ?: if (extra.tracking == "birthday") "none" else null
+                instance?.let {
                     NotificationActionManager.presentAction(
                         this,
                         supportFragmentManager,
-                        instance,
+                        it,
                         extra.instanceId ?: 0,
                         extra.postId,
                         popup = extra.popup,
@@ -701,6 +709,7 @@ class MainActivity : BaseSecuredActivity() {
         var shouldLaunchActionCreation: Boolean = false
         var shouldLaunchQuizz: Boolean = false
         var shouldLaunchWelcomeGroup: Boolean = false
+        var shouldLaunchBirthday: Boolean = false
 
         // NOUVEAU FLAG : Pour distinguer création de demande vs liste simple
         var shouldLaunchDemandCreation: Boolean = false

--- a/app/src/main/java/social/entourage/android/api/model/notification/InAppNotification.kt
+++ b/app/src/main/java/social/entourage/android/api/model/notification/InAppNotification.kt
@@ -24,6 +24,10 @@ class InAppNotification (
     val context: String? = null,
     @SerializedName("url")
     val url: String? = null,
+    @SerializedName("tracking")
+    val tracking: String? = null,
+    @SerializedName("popup")
+    val popup: String? = null,
     @SerializedName("instance")
     val instanceType: String? = null,
     @SerializedName("title")

--- a/app/src/main/java/social/entourage/android/notifications/InAppNotificationListFragment.kt
+++ b/app/src/main/java/social/entourage/android/notifications/InAppNotificationListFragment.kt
@@ -153,6 +153,8 @@ class InAppNotificationListFragment : Fragment() {
                     val instanceId = notif.instanceId ?: 0
                     val stage = notif.context
                     val notifContext = notif.context
+                    val tracking = notif.tracking
+                    val popup = notif.popup
                     val postId:Int? = notif.postId
                     if (notif.completedAt == null) {
                         itemSelected = position
@@ -161,8 +163,9 @@ class InAppNotificationListFragment : Fragment() {
                     else {
                         itemSelected = -1
                     }
-                    if(instance != null) {
-                        NotificationActionManager.presentAction(requireContext(),parentFragmentManager,instance,instanceId,postId,stage, notifContext = notifContext )
+                    if(instance != null || tracking == "birthday") {
+                        val instanceName = instance ?: "none"
+                        NotificationActionManager.presentAction(requireContext(),parentFragmentManager,instanceName,instanceId,postId,stage, popup, notifContext, tracking )
                     } else{
                         NotificationActionManager.presentWelcomeAction(requireContext(), stage)
                     }

--- a/app/src/main/java/social/entourage/android/notifications/NotificationActionManager.kt
+++ b/app/src/main/java/social/entourage/android/notifications/NotificationActionManager.kt
@@ -32,6 +32,14 @@ object NotificationActionManager {
 
     /**/
     fun presentAction(context:Context,supportFragmentManager: FragmentManager, instance:String, id:Int = 0, postId:Int?, stage:String? = "", popup:String? = "" , notifContext:String? = "", tracking:String? = ""){
+        if (tracking == "birthday") {
+            MainActivity.shouldLaunchBirthday = true
+            if (context !is MainActivity) {
+                (context as? Activity)?.finish()
+            }
+            return
+        }
+
         if(popup.equals("outing_on_day_before")){
             if(context is MainActivity){
                 (context as MainActivity).ifEventLastDay(id)


### PR DESCRIPTION
This PR implements handling for "birthday" type notifications (Push and In-App).
When a notification with `tracking: birthday` is clicked:
1. The user is redirected to the Home screen.
2. The `BirthdayActivity` is launched.

This logic is centralized in `MainActivity` via a static flag `shouldLaunchBirthday`.
`NotificationActionManager` detects the tracking type and sets this flag.
`InAppNotification` model was updated to include `tracking` and `popup` fields.
`MainActivity` and `InAppNotificationListFragment` were updated to handle cases where `instance` is null but `tracking` is "birthday".
The automatic birthday check in `HomeFragment` remains disabled as requested.

---
*PR created automatically by Jules for task [8948635336161819662](https://jules.google.com/task/8948635336161819662) started by @clemPerrousset*