### PR TITLE
Update profile display logic for association users

### DIFF
--- a/app/src/main/java/social/entourage/android/enhanced_onboarding/EnhancedOnboarding.kt
+++ b/app/src/main/java/social/entourage/android/enhanced_onboarding/EnhancedOnboarding.kt
@@ -43,7 +43,9 @@ class EnhancedOnboarding : BaseActivity() {
         viewModel.user = EntourageApplication.me(this)
 
         val userGoal = viewModel.user?.goal
-        if (userGoal != null && userGoal.equals(User.USER_GOAL_ASSO, ignoreCase = true)) {
+        val isAssoRole = viewModel.user?.partner != null && (viewModel.user?.roles?.contains("Association") == true || viewModel.user?.roles?.contains("Équipe Entourage") == true)
+
+        if ((userGoal != null && userGoal.equals(User.USER_GOAL_ASSO, ignoreCase = true)) || isAssoRole) {
             isAssociationFromSummary = true
             EntourageApplication.get().sharedPreferences.edit()
                 .putBoolean(PREF_IS_ASSOCIATION_FROM_SUMMARY, true)

--- a/app/src/main/java/social/entourage/android/profile/ProfileFullActivity.kt
+++ b/app/src/main/java/social/entourage/android/profile/ProfileFullActivity.kt
@@ -252,94 +252,119 @@ class MyProfileFullActivity : BaseSecuredActivity() {
                 )
             )
 
+            val isAsso = user.partner != null && (user.roles?.contains("Association") == true || user.roles?.contains("Équipe Entourage") == true)
+
             val actionTitleRes = if (isMe) {
                 R.string.preferences_action_title
             } else {
                 R.string.preferences_action_title_others
             }
-            val involvementsText = if (user.involvements.isNotEmpty()) {
-                user.involvements.joinToString(", ") { involvement ->
-                    when (involvement.lowercase()) {
-                        "outings" -> getString(R.string.onboarding_action_wish_event)
-                        "both_actions" -> getString(R.string.onboarding_action_wish_services)
-                        "neighborhoods" -> getString(R.string.onboarding_action_wish_network)
-                        "resources" -> getString(R.string.onboarding_action_wish_pedago)
-                        else -> getString(R.string.interest_other)
-                    }
-                }
-            } else {
-                getString(R.string.no_data_available)
-            }
-            items.add(
-                ProfileSectionItem.Item(
-                    iconRes = R.drawable.ic_profile_action,
-                    title = getString(actionTitleRes),
-                    subtitle = involvementsText
-                )
-            )
 
-            val categoriesTitleRes = if (isMe) {
-                R.string.preferences_action_categories_title
-            } else {
-                R.string.preferences_action_categories_title_others
-            }
-            val categoriesMap = mapOf(
-                "sharing_time" to getString(R.string.onboarding_category_sharing_time),
-                "material_donations" to getString(R.string.onboarding_category_donation),
-                "services" to getString(R.string.onboarding_category_services)
-            )
-            val categoriesText = if (user.concerns.isNotEmpty()) {
-                user.concerns.joinToString(", ") { concern ->
-                    categoriesMap[concern] ?: getString(R.string.interest_other)
-                }
-            } else {
-                getString(R.string.no_data_available)
-            }
-            items.add(
-                ProfileSectionItem.Item(
-                    iconRes = R.drawable.ic_name_don_materiel,
-                    title = getString(categoriesTitleRes),
-                    subtitle = categoriesText
-                )
-            )
-
-            val availabilityTitleRes = if (isMe) {
-                R.string.preferences_availability_title
-            } else {
-                R.string.preferences_availability_title_others
-            }
-            val daysMap = mapOf(
-                "1" to getString(R.string.enhanced_onboarding_time_disponibility_day_monday),
-                "2" to getString(R.string.enhanced_onboarding_time_disponibility_day_tuesday),
-                "3" to getString(R.string.enhanced_onboarding_time_disponibility_day_wednesday),
-                "4" to getString(R.string.enhanced_onboarding_time_disponibility_day_thursday),
-                "5" to getString(R.string.enhanced_onboarding_time_disponibility_day_friday),
-                "6" to getString(R.string.enhanced_onboarding_time_disponibility_day_saturday),
-                "7" to getString(R.string.enhanced_onboarding_time_disponibility_day_sunday)
-            )
-            val timeSlotsMap = mapOf(
-                "09:00-12:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_morning),
-                "14:00-18:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_afternoon),
-                "18:00-21:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_evening)
-            )
-            val availabilityText = if (user.availability.isNotEmpty()) {
-                user.availability.entries.joinToString(" ; ") { (day, times) ->
-                    val dayName = daysMap[day] ?: day
-                    val timeSlots = times.joinToString(", ") { time ->
-                        timeSlotsMap[time] ?: time
+            if (isAsso) {
+                val orientationsText = if (user.orientations.isNotEmpty()) {
+                    user.orientations.joinToString(", ") { orientation ->
+                        when (orientation) {
+                            "share" -> getString(R.string.enhanced_onboarding_asso_wish_outings)
+                            "guide" -> getString(R.string.enhanced_onboarding_asso_wish_neighborhoods)
+                            "help" -> getString(R.string.enhanced_onboarding_asso_wish_both_actions)
+                            else -> getString(R.string.interest_other)
+                        }
                     }
-                    "$dayName : $timeSlots"
+                } else {
+                    getString(R.string.no_data_available)
                 }
-            } else {
-                getString(R.string.no_data_available)
-            }
-            items.add(
-                ProfileSectionItem.Item(
-                    iconRes = R.drawable.ic_profile_availability,
-                    title = getString(availabilityTitleRes),
-                    subtitle = availabilityText
+                items.add(
+                    ProfileSectionItem.Item(
+                        iconRes = R.drawable.ic_profile_action,
+                        title = getString(actionTitleRes),
+                        subtitle = orientationsText
+                    )
                 )
-            )
+            } else {
+                val involvementsText = if (user.involvements.isNotEmpty()) {
+                    user.involvements.joinToString(", ") { involvement ->
+                        when (involvement.lowercase()) {
+                            "outings" -> getString(R.string.onboarding_action_wish_event)
+                            "both_actions" -> getString(R.string.onboarding_action_wish_services)
+                            "neighborhoods" -> getString(R.string.onboarding_action_wish_network)
+                            "resources" -> getString(R.string.onboarding_action_wish_pedago)
+                            else -> getString(R.string.interest_other)
+                        }
+                    }
+                } else {
+                    getString(R.string.no_data_available)
+                }
+                items.add(
+                    ProfileSectionItem.Item(
+                        iconRes = R.drawable.ic_profile_action,
+                        title = getString(actionTitleRes),
+                        subtitle = involvementsText
+                    )
+                )
+
+                val categoriesTitleRes = if (isMe) {
+                    R.string.preferences_action_categories_title
+                } else {
+                    R.string.preferences_action_categories_title_others
+                }
+                val categoriesMap = mapOf(
+                    "sharing_time" to getString(R.string.onboarding_category_sharing_time),
+                    "material_donations" to getString(R.string.onboarding_category_donation),
+                    "services" to getString(R.string.onboarding_category_services)
+                )
+                val categoriesText = if (user.concerns.isNotEmpty()) {
+                    user.concerns.joinToString(", ") { concern ->
+                        categoriesMap[concern] ?: getString(R.string.interest_other)
+                    }
+                } else {
+                    getString(R.string.no_data_available)
+                }
+                items.add(
+                    ProfileSectionItem.Item(
+                        iconRes = R.drawable.ic_name_don_materiel,
+                        title = getString(categoriesTitleRes),
+                        subtitle = categoriesText
+                    )
+                )
+
+                val availabilityTitleRes = if (isMe) {
+                    R.string.preferences_availability_title
+                } else {
+                    R.string.preferences_availability_title_others
+                }
+                val daysMap = mapOf(
+                    "1" to getString(R.string.enhanced_onboarding_time_disponibility_day_monday),
+                    "2" to getString(R.string.enhanced_onboarding_time_disponibility_day_tuesday),
+                    "3" to getString(R.string.enhanced_onboarding_time_disponibility_day_wednesday),
+                    "4" to getString(R.string.enhanced_onboarding_time_disponibility_day_thursday),
+                    "5" to getString(R.string.enhanced_onboarding_time_disponibility_day_friday),
+                    "6" to getString(R.string.enhanced_onboarding_time_disponibility_day_saturday),
+                    "7" to getString(R.string.enhanced_onboarding_time_disponibility_day_sunday)
+                )
+                val timeSlotsMap = mapOf(
+                    "09:00-12:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_morning),
+                    "14:00-18:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_afternoon),
+                    "18:00-21:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_evening)
+                )
+                val availabilityText = if (user.availability.isNotEmpty()) {
+                    user.availability.entries.joinToString(" ; ") { (day, times) ->
+                        val dayName = daysMap[day] ?: day
+                        val timeSlots = times.joinToString(", ") { time ->
+                            timeSlotsMap[time] ?: time
+                        }
+                        "$dayName : $timeSlots"
+                    }
+                } else {
+                    getString(R.string.no_data_available)
+                }
+                items.add(
+                    ProfileSectionItem.Item(
+                        iconRes = R.drawable.ic_profile_availability,
+                        title = getString(availabilityTitleRes),
+                        subtitle = availabilityText
+                    )
+                )
+            }
 
             if (isMe) {
                 items.add(ProfileSectionItem.Separator(getString(R.string.settings_section_title)))
@@ -924,94 +949,119 @@ class ProfileFullActivity : BaseSecuredActivity() {
                 )
             )
 
+            val isAsso = user.partner != null && (user.roles?.contains("Association") == true || user.roles?.contains("Équipe Entourage") == true)
+
             val actionTitleRes = if (isMe) {
                 R.string.preferences_action_title
             } else {
                 R.string.preferences_action_title_others
             }
-            val involvementsText = if (user.involvements.isNotEmpty()) {
-                user.involvements.joinToString(", ") { involvement ->
-                    when (involvement.lowercase()) {
-                        "outings" -> getString(R.string.onboarding_action_wish_event)
-                        "both_actions" -> getString(R.string.onboarding_action_wish_services)
-                        "neighborhoods" -> getString(R.string.onboarding_action_wish_network)
-                        "resources" -> getString(R.string.onboarding_action_wish_pedago)
-                        else -> getString(R.string.interest_other)
-                    }
-                }
-            } else {
-                getString(R.string.no_data_available)
-            }
-            items.add(
-                ProfileSectionItem.Item(
-                    iconRes = R.drawable.ic_profile_action,
-                    title = getString(actionTitleRes),
-                    subtitle = involvementsText
-                )
-            )
 
-            val categoriesTitleRes = if (isMe) {
-                R.string.preferences_action_categories_title
-            } else {
-                R.string.preferences_action_categories_title_others
-            }
-            val categoriesMap = mapOf(
-                "sharing_time" to getString(R.string.onboarding_category_sharing_time),
-                "material_donations" to getString(R.string.onboarding_category_donation),
-                "services" to getString(R.string.onboarding_category_services)
-            )
-            val categoriesText = if (user.concerns.isNotEmpty()) {
-                user.concerns.joinToString(", ") { concern ->
-                    categoriesMap[concern] ?: getString(R.string.interest_other)
-                }
-            } else {
-                getString(R.string.no_data_available)
-            }
-            items.add(
-                ProfileSectionItem.Item(
-                    iconRes = R.drawable.ic_name_don_materiel,
-                    title = getString(categoriesTitleRes),
-                    subtitle = categoriesText
-                )
-            )
-
-            val availabilityTitleRes = if (isMe) {
-                R.string.preferences_availability_title
-            } else {
-                R.string.preferences_availability_title_others
-            }
-            val daysMap = mapOf(
-                "1" to getString(R.string.enhanced_onboarding_time_disponibility_day_monday),
-                "2" to getString(R.string.enhanced_onboarding_time_disponibility_day_tuesday),
-                "3" to getString(R.string.enhanced_onboarding_time_disponibility_day_wednesday),
-                "4" to getString(R.string.enhanced_onboarding_time_disponibility_day_thursday),
-                "5" to getString(R.string.enhanced_onboarding_time_disponibility_day_friday),
-                "6" to getString(R.string.enhanced_onboarding_time_disponibility_day_saturday),
-                "7" to getString(R.string.enhanced_onboarding_time_disponibility_day_sunday)
-            )
-            val timeSlotsMap = mapOf(
-                "09:00-12:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_morning),
-                "14:00-18:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_afternoon),
-                "18:00-21:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_evening)
-            )
-            val availabilityText = if (user.availability.isNotEmpty()) {
-                user.availability.entries.joinToString(" ; ") { (day, times) ->
-                    val dayName = daysMap[day] ?: day
-                    val timeSlots = times.joinToString(", ") { time ->
-                        timeSlotsMap[time] ?: time
+            if (isAsso) {
+                val orientationsText = if (user.orientations.isNotEmpty()) {
+                    user.orientations.joinToString(", ") { orientation ->
+                        when (orientation) {
+                            "share" -> getString(R.string.enhanced_onboarding_asso_wish_outings)
+                            "guide" -> getString(R.string.enhanced_onboarding_asso_wish_neighborhoods)
+                            "help" -> getString(R.string.enhanced_onboarding_asso_wish_both_actions)
+                            else -> getString(R.string.interest_other)
+                        }
                     }
-                    "$dayName : $timeSlots"
+                } else {
+                    getString(R.string.no_data_available)
                 }
-            } else {
-                getString(R.string.no_data_available)
-            }
-            items.add(
-                ProfileSectionItem.Item(
-                    iconRes = R.drawable.ic_profile_availability,
-                    title = getString(availabilityTitleRes),
-                    subtitle = availabilityText
+                items.add(
+                    ProfileSectionItem.Item(
+                        iconRes = R.drawable.ic_profile_action,
+                        title = getString(actionTitleRes),
+                        subtitle = orientationsText
+                    )
                 )
-            )
+            } else {
+                val involvementsText = if (user.involvements.isNotEmpty()) {
+                    user.involvements.joinToString(", ") { involvement ->
+                        when (involvement.lowercase()) {
+                            "outings" -> getString(R.string.onboarding_action_wish_event)
+                            "both_actions" -> getString(R.string.onboarding_action_wish_services)
+                            "neighborhoods" -> getString(R.string.onboarding_action_wish_network)
+                            "resources" -> getString(R.string.onboarding_action_wish_pedago)
+                            else -> getString(R.string.interest_other)
+                        }
+                    }
+                } else {
+                    getString(R.string.no_data_available)
+                }
+                items.add(
+                    ProfileSectionItem.Item(
+                        iconRes = R.drawable.ic_profile_action,
+                        title = getString(actionTitleRes),
+                        subtitle = involvementsText
+                    )
+                )
+
+                val categoriesTitleRes = if (isMe) {
+                    R.string.preferences_action_categories_title
+                } else {
+                    R.string.preferences_action_categories_title_others
+                }
+                val categoriesMap = mapOf(
+                    "sharing_time" to getString(R.string.onboarding_category_sharing_time),
+                    "material_donations" to getString(R.string.onboarding_category_donation),
+                    "services" to getString(R.string.onboarding_category_services)
+                )
+                val categoriesText = if (user.concerns.isNotEmpty()) {
+                    user.concerns.joinToString(", ") { concern ->
+                        categoriesMap[concern] ?: getString(R.string.interest_other)
+                    }
+                } else {
+                    getString(R.string.no_data_available)
+                }
+                items.add(
+                    ProfileSectionItem.Item(
+                        iconRes = R.drawable.ic_name_don_materiel,
+                        title = getString(categoriesTitleRes),
+                        subtitle = categoriesText
+                    )
+                )
+
+                val availabilityTitleRes = if (isMe) {
+                    R.string.preferences_availability_title
+                } else {
+                    R.string.preferences_availability_title_others
+                }
+                val daysMap = mapOf(
+                    "1" to getString(R.string.enhanced_onboarding_time_disponibility_day_monday),
+                    "2" to getString(R.string.enhanced_onboarding_time_disponibility_day_tuesday),
+                    "3" to getString(R.string.enhanced_onboarding_time_disponibility_day_wednesday),
+                    "4" to getString(R.string.enhanced_onboarding_time_disponibility_day_thursday),
+                    "5" to getString(R.string.enhanced_onboarding_time_disponibility_day_friday),
+                    "6" to getString(R.string.enhanced_onboarding_time_disponibility_day_saturday),
+                    "7" to getString(R.string.enhanced_onboarding_time_disponibility_day_sunday)
+                )
+                val timeSlotsMap = mapOf(
+                    "09:00-12:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_morning),
+                    "14:00-18:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_afternoon),
+                    "18:00-21:00" to getString(R.string.enhanced_onboarding_time_disponibility_time_evening)
+                )
+                val availabilityText = if (user.availability.isNotEmpty()) {
+                    user.availability.entries.joinToString(" ; ") { (day, times) ->
+                        val dayName = daysMap[day] ?: day
+                        val timeSlots = times.joinToString(", ") { time ->
+                            timeSlotsMap[time] ?: time
+                        }
+                        "$dayName : $timeSlots"
+                    }
+                } else {
+                    getString(R.string.no_data_available)
+                }
+                items.add(
+                    ProfileSectionItem.Item(
+                        iconRes = R.drawable.ic_profile_availability,
+                        title = getString(availabilityTitleRes),
+                        subtitle = availabilityText
+                    )
+                )
+            }
 
             if (isMe) {
                 items.add(ProfileSectionItem.Separator(getString(R.string.settings_section_title)))


### PR DESCRIPTION
This change customizes the profile view for users belonging to an association (Partner + Role). It replaces the standard action/involvement section with an 'Orientations' section specific to associations and hides irrelevant sections (categories, availability). It also ensures the edit navigation directs to the correct onboarding flow.

---
*PR created automatically by Jules for task [16645883503484565550](https://jules.google.com/task/16645883503484565550) started by @clemPerrousset*