### PR TITLE
Condition 'Se sensibiliser' visibility on user wish

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -756,7 +756,16 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
 
         this.homeInitialPedagoAdapter.resetData(allPedago)
 
-        val show = allPedago.isNotEmpty()
+        var show = allPedago.isNotEmpty()
+        val me = EntourageApplication.me(activity)
+        if (show && me != null) {
+            val involvements = me.involvements
+            val hasResourcesWish = involvements.any { it.equals("resources", ignoreCase = true) }
+            if (!hasResourcesWish) {
+                show = false
+            }
+        }
+
         initialPedagoHeaderAdapter.update(getString(R.string.home_title_sensibilisation), getString(R.string.home_subtitle_sensibilisation), show)
         initialPedagoWrapperAdapter.setVisible(show)
     }


### PR DESCRIPTION
Conditionally hide the 'Se sensibiliser' section on the Home screen if the user has not selected the 'resources' action wish (Apprendre avec des contenus pédagogiques). The check is performed against the user's `involvements` list. The other pedagogical section 'Tout savoir pour passer à l'action' remains unaffected.

---
*PR created automatically by Jules for task [18172559030753636978](https://jules.google.com/task/18172559030753636978) started by @clemPerrousset*