### PR TITLE
Refresh user profile data on Resume

### DIFF
--- a/app/src/main/java/social/entourage/android/profile/ProfileFullActivity.kt
+++ b/app/src/main/java/social/entourage/android/profile/ProfileFullActivity.kt
@@ -97,10 +97,10 @@ class MyProfileFullActivity : BaseSecuredActivity() {
 
     override fun onResume() {
         super.onResume()
+        userPresenter.getUser(id)
         if (user == null) {
             binding.progressBar.visibility = View.VISIBLE
             Timber.e("user is null in resume Profile Screen")
-            userPresenter.getUser(id)
         }
         EnhancedOnboarding.isFromSettingsWishes = false
         EnhancedOnboarding.isFromSettingsDisponibility = false
@@ -174,12 +174,8 @@ class MyProfileFullActivity : BaseSecuredActivity() {
     private fun updateUser(user: User) {
         notifSubTitle = ""
         notifBlocked = ""
-        val forceInit = this.user?.id != user.id
         this.user = user
-        if (forceInit) {
-            Timber.e("user reinit")
-            initUserInfo()
-        }
+        initUserInfo()
     }
 
     private fun setPartnerClickListener() {
@@ -807,10 +803,10 @@ class ProfileFullActivity : BaseSecuredActivity() {
 
     override fun onResume() {
         super.onResume()
+        userPresenter.getUser(id)
         if (user == null) {
             binding.progressBar.visibility = View.VISIBLE
             Timber.e("user is null in resume Profile Screen")
-            userPresenter.getUser(id)
         }
         EnhancedOnboarding.isFromSettingsWishes = false
         EnhancedOnboarding.isFromSettingsDisponibility = false
@@ -884,12 +880,8 @@ class ProfileFullActivity : BaseSecuredActivity() {
     private fun updateUser(user: User) {
         notifSubTitle = ""
         notifBlocked = ""
-        val forceInit = this.user?.id != user.id
         this.user = user
-        if (forceInit) {
-            Timber.e("user reinit")
-            initUserInfo()
-        }
+        initUserInfo()
     }
 
     private fun setScrollEffects(isMe: Boolean) {


### PR DESCRIPTION
This change updates both MyProfileFullActivity and ProfileFullActivity to unconditionally fetch user data from the backend in onResume. This ensures that any changes made to the profile (e.g., in edit mode or other screens) are immediately reflected when the user returns to the profile view. Additionally, the updateUser method now forces a UI refresh even if the user ID has not changed, ensuring that the displayed data (stats, interests, etc.) is always up-to-date.

---
*PR created automatically by Jules for task [6664609752999027645](https://jules.google.com/task/6664609752999027645) started by @clemPerrousset*