### PR TITLE
Fix Home tab redirection to Event tab after Enhanced Onboarding

### DIFF
--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -183,10 +183,9 @@ class MainActivity : BaseSecuredActivity() {
         // On remet les flags à false immédiatement pour éviter les boucles
 
         // 1. Redirection vers l'onglet Événements
-        if (shouldLaunchEvent) {
-            shouldLaunchEvent = false
-            goEvent()
-        }
+        // La redirection se fait désormais via l'intent (goDiscoverEvent) pour éviter les boucles
+        // lors du changement d'onglet manuel. Le flag shouldLaunchEvent est conservé uniquement
+        // pour que le Fragment Events sache qu'il doit afficher la bulle d'info.
 
         // 2. Lancement Création de Demande (Both actions ou No event)
         // Utilise la variable distincte pour éviter de lancer la liste

--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -324,15 +324,18 @@ class MainActivity : BaseSecuredActivity() {
 
 
         if (goContrib) {
+            intent.removeExtra("goContrib")
             goContrib()
             return
         }
         else if(goDiscoverGroup){
+            intent.removeExtra("goDiscoverGroup")
             this.setGoDiscoverGroupFromDeepL(goDiscoverGroup)
             goGroup()
             return
         }
         else if(goDiscoverEvent){
+            intent.removeExtra("goDiscoverEvent")
             goEvent()
             return
         }

--- a/app/src/main/java/social/entourage/android/enhanced_onboarding/EnhancedOnboarding.kt
+++ b/app/src/main/java/social/entourage/android/enhanced_onboarding/EnhancedOnboarding.kt
@@ -215,6 +215,7 @@ class EnhancedOnboarding : BaseActivity() {
                 }
                 "event" -> {
                     MainActivity.shouldLaunchEvent = true
+                    intent.putExtra("goDiscoverEvent", true)
                 }
                 "contribution" -> {
                     intent.putExtra("goContrib", true)


### PR DESCRIPTION
This PR fixes a bug where the Home tab would persistently redirect to the Event tab after completing Enhanced Onboarding with the "Event" goal.

The issue was caused by a static flag `shouldLaunchEvent` in `MainActivity` that, under certain conditions, triggered navigation logic in `onResume`. By moving the navigation trigger to an Intent extra (`goDiscoverEvent`) sent from `EnhancedOnboarding`, the navigation becomes a one-time event handled by `onNewIntent`/`useIntentForRedictection`, preventing the loop. The static flag is preserved but repurposed strictly for UI state (showing the "filters saved" bubble) in `EventsFragment`.

---
*PR created automatically by Jules for task [4449826352069020399](https://jules.google.com/task/4449826352069020399) started by @clemPerrousset*