### PR TITLE
Refactor Onboarding Navigation to use Sealed Class

### DIFF
--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -56,6 +56,7 @@ import social.entourage.android.tools.updatePaddingBottomForEdgeToEdge
 import social.entourage.android.tools.utils.Const
 import social.entourage.android.tools.view.WebViewFragment
 import social.entourage.android.user.UserPresenter
+import social.entourage.android.enhanced_onboarding.OnboardingNavigation
 import social.entourage.android.welcome.WelcomeTwoActivity
 import timber.log.Timber
 
@@ -179,54 +180,6 @@ class MainActivity : BaseSecuredActivity() {
             shouldLaunchEventPopUp = 0
         }
 
-        // --- GESTION CENTRALISÉE DES REDIRECTIONS ---
-        // On remet les flags à false immédiatement pour éviter les boucles
-
-        // 1. Redirection vers l'onglet Événements
-        // La redirection se fait désormais via l'intent (goDiscoverEvent) pour éviter les boucles
-        // lors du changement d'onglet manuel. Le flag shouldLaunchEvent est conservé uniquement
-        // pour que le Fragment Events sache qu'il doit afficher la bulle d'info.
-
-        // 2. Lancement Création de Demande (Both actions ou No event)
-        // Utilise la variable distincte pour éviter de lancer la liste
-        if (shouldLaunchDemandCreation) {
-            shouldLaunchDemandCreation = false
-            val intent = Intent(this, CreateActionActivity::class.java)
-            intent.putExtra(Const.IS_ACTION_DEMAND, true)
-            this.startActivity(intent)
-            overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
-        }
-
-        // 3. Ancienne variable de fallback (si jamais utilisée ailleurs)
-        if (shouldLaunchActionCreation) {
-            shouldLaunchActionCreation = false
-            val intent = Intent(this, CreateActionActivity::class.java)
-            intent.putExtra(Const.IS_ACTION_DEMAND, false)
-            this.startActivity(intent)
-            overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
-        }
-
-        // 4. Lancement du Quizz (Ressources)
-        if (shouldLaunchQuizz) {
-            shouldLaunchQuizz = false
-            val urlString = "https://kahoot.it/challenge/45371e80-fe50-4be5-afec-b37e3d50ede2_1733228323615"
-            WebViewFragment.newInstance(urlString, 0, true)
-                .show(supportFragmentManager, WebViewFragment.TAG)
-        }
-
-        // 5. Lancement Welcome Group
-        if (shouldLaunchWelcomeGroup) {
-            shouldLaunchWelcomeGroup = false
-            val intent = Intent(this, WelcomeTwoActivity::class.java)
-            this.startActivity(intent)
-            overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
-        }
-
-        // 6. Retour au profil (Settings)
-        if (shouldLaunchProfile) {
-            shouldLaunchProfile = false
-            showProfile()
-        }
     }
 
     private fun checkForAppUpdate() {
@@ -299,7 +252,48 @@ class MainActivity : BaseSecuredActivity() {
         }
     }
 
+    private fun handleOnboardingNavigation(navigation: OnboardingNavigation) {
+        when (navigation) {
+            is OnboardingNavigation.WelcomeGroup -> {
+                val intent = Intent(this, WelcomeTwoActivity::class.java)
+                startActivity(intent)
+                overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
+            }
+            is OnboardingNavigation.Events -> {
+                shouldLaunchEvent = true
+                goEvent()
+            }
+            is OnboardingNavigation.Donations -> {
+                goContrib()
+            }
+            is OnboardingNavigation.CreateActionDemand -> {
+                val intent = Intent(this, CreateActionActivity::class.java)
+                intent.putExtra(Const.IS_ACTION_DEMAND, true)
+                startActivity(intent)
+                overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
+            }
+            is OnboardingNavigation.Quiz -> {
+                val urlString = "https://kahoot.it/challenge/45371e80-fe50-4be5-afec-b37e3d50ede2_1733228323615"
+                WebViewFragment.newInstance(urlString, 0, true)
+                    .show(supportFragmentManager, WebViewFragment.TAG)
+            }
+            is OnboardingNavigation.Profile -> {
+                showProfile()
+            }
+            is OnboardingNavigation.Home -> {
+                // Stay on home
+            }
+        }
+    }
+
     fun useIntentForRedictection(intent: Intent) {
+        val onboardingNav = intent.getParcelableExtra<OnboardingNavigation>("extra_onboarding_navigation")
+        if (onboardingNav != null) {
+            intent.removeExtra("extra_onboarding_navigation")
+            handleOnboardingNavigation(onboardingNav)
+            return
+        }
+
         intent.action?.let { action ->
             checkIntentAction(action, intent.extras)
         }
@@ -697,14 +691,7 @@ class MainActivity : BaseSecuredActivity() {
         var orientations: MutableList<userConfig>? = null
         var shouldLaunchEventPopUp: Int = 0
         var shouldLaunchOnboarding: Boolean = false
-        var shouldLaunchProfile: Boolean = false
         var isFromProfile: Boolean = false
         var shouldLaunchEvent: Boolean = false
-        var shouldLaunchActionCreation: Boolean = false
-        var shouldLaunchQuizz: Boolean = false
-        var shouldLaunchWelcomeGroup: Boolean = false
-
-        // NOUVEAU FLAG : Pour distinguer création de demande vs liste simple
-        var shouldLaunchDemandCreation: Boolean = false
     }
 }

--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -606,7 +606,12 @@ class MainActivity : BaseSecuredActivity() {
                 }
             }
             // LA navigation est faite ici par NavigationUI, toi tu ne navigues pas ailleurs.
-            NavigationUI.onNavDestinationSelected(item, navController)
+            val handled = NavigationUI.onNavDestinationSelected(item, navController)
+            if (!handled && item.itemId == R.id.navigation_home) {
+                goHome()
+                return@setOnItemSelectedListener true
+            }
+            handled
         }
     }
 

--- a/app/src/main/java/social/entourage/android/enhanced_onboarding/EnhancedOnboarding.kt
+++ b/app/src/main/java/social/entourage/android/enhanced_onboarding/EnhancedOnboarding.kt
@@ -197,59 +197,26 @@ class EnhancedOnboarding : BaseActivity() {
                 putBoolean("PREF_ENHANCED_ONBOARDING_COMPLETED", true)
             }
 
-            // 1. Réinitialisation préventive de TOUS les flags de MainActivity
-            // Cela évite les conflits si plusieurs flags étaient restés true
-            MainActivity.shouldLaunchEvent = false
-            MainActivity.shouldLaunchWelcomeGroup = false
-            MainActivity.shouldLaunchQuizz = false
-            MainActivity.shouldLaunchActionCreation = false
-            MainActivity.shouldLaunchDemandCreation = false // On reset le nouveau flag
-            MainActivity.shouldLaunchProfile = false
+            val navigation: OnboardingNavigation = if (isFromSettingsinterest || isFromSettingsDisponibility || isFromSettingsWishes || isFromSettingsActionCategorie || MainActivity.isFromProfile) {
+                isFromSettingsinterest = false
+                isFromSettingsDisponibility = false
+                isFromSettingsWishes = false
+                isFromSettingsActionCategorie = false
+                OnboardingNavigation.Profile
+            } else {
+                when (viewModel.selectedCategory) {
+                    "neighborhoods" -> OnboardingNavigation.WelcomeGroup
+                    "event" -> OnboardingNavigation.Events
+                    "contribution" -> OnboardingNavigation.Donations
+                    "both_actions" -> OnboardingNavigation.CreateActionDemand
+                    "resources" -> OnboardingNavigation.Quiz
+                    "no_event" -> OnboardingNavigation.CreateActionDemand
+                    else -> OnboardingNavigation.Home
+                }
+            }
 
             val intent = Intent(this, MainActivity::class.java)
-
-            // Mapping des actions en fonction de la catégorie choisie
-            when (viewModel.selectedCategory) {
-                "neighborhoods" -> {
-                    MainActivity.shouldLaunchWelcomeGroup = true
-                }
-                "event" -> {
-                    MainActivity.shouldLaunchEvent = true
-                    intent.putExtra("goDiscoverEvent", true)
-                }
-                "contribution" -> {
-                    intent.putExtra("goContrib", true)
-                }
-                "both_actions" -> {
-                    // C'est ICI qu'on déclenche la CREATION de demande
-                    MainActivity.shouldLaunchDemandCreation = true
-                }
-                "resources" -> {
-                    MainActivity.shouldLaunchQuizz = true
-                }
-                "no_event" -> {
-                    // Idem, on lance la création de demande par défaut
-                    MainActivity.shouldLaunchDemandCreation = true
-                }
-                else -> {
-                    // Cas par défaut (Home)
-                }
-            }
-
-            // Gestion du retour des Settings (prioritaire)
-            if (isFromSettingsinterest || isFromSettingsDisponibility || isFromSettingsWishes || isFromSettingsActionCategorie || MainActivity.isFromProfile) {
-                isFromSettingsinterest = false
-
-                // On annule les redirections "découverte" pour juste revenir au profil
-                MainActivity.shouldLaunchEvent = false
-                MainActivity.shouldLaunchWelcomeGroup = false
-                MainActivity.shouldLaunchActionCreation = false
-                MainActivity.shouldLaunchDemandCreation = false
-                MainActivity.shouldLaunchQuizz = false
-                intent.removeExtra("goContrib")
-
-                MainActivity.shouldLaunchProfile = true
-            }
+            intent.putExtra("extra_onboarding_navigation", navigation)
 
             // Nettoyage de la stack pour repartir proprement sur MainActivity
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK

--- a/app/src/main/java/social/entourage/android/enhanced_onboarding/OnboardingNavigation.kt
+++ b/app/src/main/java/social/entourage/android/enhanced_onboarding/OnboardingNavigation.kt
@@ -1,0 +1,69 @@
+package social.entourage.android.enhanced_onboarding
+
+import android.os.Parcel
+import android.os.Parcelable
+
+sealed class OnboardingNavigation : Parcelable {
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {
+        dest.writeInt(getTypeId())
+    }
+
+    protected abstract fun getTypeId(): Int
+
+    companion object CREATOR : Parcelable.Creator<OnboardingNavigation> {
+        const val TYPE_HOME = 0
+        const val TYPE_WELCOME_GROUP = 1
+        const val TYPE_EVENTS = 2
+        const val TYPE_DONATIONS = 3
+        const val TYPE_CREATE_ACTION_DEMAND = 4
+        const val TYPE_QUIZ = 5
+        const val TYPE_PROFILE = 6
+
+        override fun createFromParcel(source: Parcel): OnboardingNavigation {
+            return when (source.readInt()) {
+                TYPE_WELCOME_GROUP -> WelcomeGroup
+                TYPE_EVENTS -> Events
+                TYPE_DONATIONS -> Donations
+                TYPE_CREATE_ACTION_DEMAND -> CreateActionDemand
+                TYPE_QUIZ -> Quiz
+                TYPE_PROFILE -> Profile
+                else -> Home
+            }
+        }
+
+        override fun newArray(size: Int): Array<OnboardingNavigation?> {
+            return arrayOfNulls(size)
+        }
+    }
+
+    object Home : OnboardingNavigation() {
+        override fun getTypeId() = TYPE_HOME
+    }
+
+    object WelcomeGroup : OnboardingNavigation() {
+        override fun getTypeId() = TYPE_WELCOME_GROUP
+    }
+
+    object Events : OnboardingNavigation() {
+        override fun getTypeId() = TYPE_EVENTS
+    }
+
+    object Donations : OnboardingNavigation() {
+        override fun getTypeId() = TYPE_DONATIONS
+    }
+
+    object CreateActionDemand : OnboardingNavigation() {
+        override fun getTypeId() = TYPE_CREATE_ACTION_DEMAND
+    }
+
+    object Quiz : OnboardingNavigation() {
+        override fun getTypeId() = TYPE_QUIZ
+    }
+
+    object Profile : OnboardingNavigation() {
+        override fun getTypeId() = TYPE_PROFILE
+    }
+}

--- a/app/src/main/java/social/entourage/android/enhanced_onboarding/fragments/OnboardingCongratsFragment.kt
+++ b/app/src/main/java/social/entourage/android/enhanced_onboarding/fragments/OnboardingCongratsFragment.kt
@@ -45,12 +45,6 @@ class OnboardingCongratsFragment: Fragment() {
         binding.lottieAnimation.playAnimation()
         binding.buttonStart.setOnClickListener {
             AnalyticsEvents.logEvent(AnalyticsEvents.onboarding_end_browse_events_clic)
-            if(MainActivity.isFromProfile) {
-                MainActivity.shouldLaunchEvent = false
-                MainActivity.shouldLaunchWelcomeGroup = false
-                MainActivity.shouldLaunchQuizz = false
-                MainActivity.shouldLaunchActionCreation = false
-            }
             AnalyticsEvents.logEvent(AnalyticsEvents.onboarding_end_congrats_clic_on_ + category)
             viewModel.registerAndQuit(category)
         }


### PR DESCRIPTION
Refactored the navigation logic at the end of the Enhanced Onboarding flow.
Instead of setting multiple static boolean flags in `MainActivity` (like `shouldLaunchWelcomeGroup`, `shouldLaunchDemandCreation`, etc.), the `EnhancedOnboarding` activity now creates an `OnboardingNavigation` object (a Parcelable sealed class) representing the destination.
This object is passed to `MainActivity` via an Intent extra. `MainActivity` processes this object in `handleOnboardingNavigation` to trigger the appropriate navigation action (starting an activity or switching tabs).
This removes the fragility of global mutable state and prevents potential navigation loops.
Obsolete flags were removed from `MainActivity`. `shouldLaunchEvent` is kept but only used for UI state communication (showing a bubble) within the Events tab, and is set properly by the new navigation handler.

---
*PR created automatically by Jules for task [3682242122781392554](https://jules.google.com/task/3682242122781392554) started by @clemPerrousset*