### PR TITLE
Replace okhttp3-idling-resource with local implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -256,14 +256,12 @@ dependencies {
     // Instrumentation tests
     androidTestImplementation(libs.espresso.core)
     androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.espresso.core)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.test.core.ktx)
 
     androidTestImplementation(libs.androidx.uiautomator)
     androidTestImplementation(libs.espresso.intents)
-    androidTestImplementation(libs.okhttp3.idling.resource)
     androidTestImplementation(libs.androidx.arch.core.testing)
 
     // Unit tests

--- a/app/src/androidTest/java/social/entourage/android/EntourageTestWithAPI.kt
+++ b/app/src/androidTest/java/social/entourage/android/EntourageTestWithAPI.kt
@@ -7,7 +7,6 @@ import android.view.autofill.AutofillManager
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
 import androidx.test.platform.app.InstrumentationRegistry
-import com.jakewharton.espresso.OkHttp3IdlingResource
 
 open class EntourageTestWithAPI {
     private var afM: AutofillManager? = null
@@ -26,7 +25,7 @@ open class EntourageTestWithAPI {
         }
 
         val client = EntourageApplication[activity].apiModule.okHttpClient
-        resource = OkHttp3IdlingResource.create("OkHttp", client)
+        resource = OkHttpIdlingResource.create("OkHttp", client)
         IdlingRegistry.getInstance().register(resource)
 
         enableWifiAndData(true)

--- a/app/src/androidTest/java/social/entourage/android/OkHttpIdlingResource.kt
+++ b/app/src/androidTest/java/social/entourage/android/OkHttpIdlingResource.kt
@@ -1,0 +1,50 @@
+package social.entourage.android
+
+import androidx.test.espresso.IdlingResource
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+
+/**
+ * A custom [IdlingResource] for OkHttp.
+ *
+ * This is a replacement for the unmaintained `com.jakewharton.espresso:okhttp3-idling-resource`.
+ * It uses the OkHttp [Dispatcher.idleCallback] to notify Espresso when the network is idle.
+ */
+class OkHttpIdlingResource private constructor(
+    private val name: String,
+    private val dispatcher: Dispatcher
+) : IdlingResource {
+
+    companion object {
+        /**
+         * Create a new [IdlingResource] from [client] with [name].
+         */
+        @JvmStatic
+        fun create(name: String, client: OkHttpClient): OkHttpIdlingResource {
+            return OkHttpIdlingResource(name, client.dispatcher)
+        }
+    }
+
+    @Volatile
+    private var callback: IdlingResource.ResourceCallback? = null
+
+    init {
+        dispatcher.idleCallback = Runnable {
+            callback?.onTransitionToIdle()
+        }
+    }
+
+    override fun getName(): String = name
+
+    override fun isIdleNow(): Boolean {
+        val idle = dispatcher.runningCallsCount() == 0
+        if (idle) {
+            callback?.onTransitionToIdle()
+        }
+        return idle
+    }
+
+    override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
+        this.callback = callback
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -38,7 +38,6 @@ androidx-test-rules = "1.7.0"
 androidx-test-core = "1.7.0"
 androidx-uiautomator = "2.3.0"
 espresso-intents = "3.7.0"
-okhttp3-idling-resource = "1.0.0"
 androidx-arch-core-testing = "2.2.0"
 junit = "4.13.2"
 mockito-core = "5.21.0"
@@ -115,7 +114,6 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "androidx-test-core" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
 espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso-intents" }
-okhttp3-idling-resource = { module = "com.jakewharton.espresso:okhttp3-idling-resource", version.ref = "okhttp3-idling-resource" }
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-core-testing" }
 junit = { module = "junit:junit", version.ref = "junit" }
 test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }


### PR DESCRIPTION
Replaced the unmaintained `com.jakewharton.espresso:okhttp3-idling-resource` library with a custom Kotlin implementation (`OkHttpIdlingResource`) within the project. This removes a stale dependency and uses the recommended OkHttp `Dispatcher` APIs for Espresso synchronization. Verified by compiling instrumented tests and running existing unit tests.

---
*PR created automatically by Jules for task [13590913011107129631](https://jules.google.com/task/13590913011107129631) started by @FrPellissier*