### PR TITLE
Fix Espresso dependencies and version catalog error

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -256,13 +256,14 @@ dependencies {
     // Instrumentation tests
     androidTestImplementation(libs.espresso.core)
     androidTestImplementation(libs.androidx.test.ext.junit)
-    androidTestImplementation(libs.espresso.core)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.test.core.ktx)
 
     androidTestImplementation(libs.androidx.uiautomator)
     androidTestImplementation(libs.espresso.intents)
+    androidTestImplementation(libs.androidx.espresso.contrib)
+    androidTestImplementation(libs.espresso.idling.resource)
     androidTestImplementation(libs.okhttp3.idling.resource)
     androidTestImplementation(libs.androidx.arch.core.testing)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -262,7 +262,9 @@ dependencies {
 
     androidTestImplementation(libs.androidx.uiautomator)
     androidTestImplementation(libs.espresso.intents)
-    androidTestImplementation(libs.androidx.espresso.contrib)
+    androidTestImplementation(libs.androidx.espresso.contrib) {
+        exclude(group = "com.google.protobuf", module = "protobuf-lite")
+    }
     androidTestImplementation(libs.espresso.idling.resource)
     androidTestImplementation(libs.okhttp3.idling.resource)
     androidTestImplementation(libs.androidx.arch.core.testing)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ material = "1.13.0"
 glide = "4.16.0"
 shortcut-badger = "1.1.22"
 keyboard-visibility-event = "3.0.0-RC3"
-espresso-core = "3.7.0"
+espresso = "3.7.0"
 facebook = "18.1.3"
 javax-annotation = "10.0-b28"
 androidx-test-ext-junit = "1.3.0"
@@ -37,7 +37,6 @@ androidx-test-runner = "1.7.0"
 androidx-test-rules = "1.7.0"
 androidx-test-core = "1.7.0"
 androidx-uiautomator = "2.3.0"
-espresso-intents = "3.7.0"
 okhttp3-idling-resource = "1.0.0"
 androidx-arch-core-testing = "2.2.0"
 junit = "4.13.2"
@@ -105,7 +104,7 @@ glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
 shortcut-badger = { module = "me.leolin:ShortcutBadger", version.ref = "shortcut-badger" }
 keyboard-visibility-event = { module = "net.yslibrary.keyboardvisibilityevent:keyboardvisibilityevent", version.ref = "keyboard-visibility-event" }
-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso-core" }
+espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "espresso" }
 facebook-android-sdk = { module = "com.facebook.android:facebook-android-sdk", version.ref = "facebook" }
 facebook-core = { module = "com.facebook.android:facebook-core", version.ref = "facebook" }
 javax-annotation = { module = "org.glassfish:javax.annotation", version.ref = "javax-annotation" }
@@ -114,7 +113,9 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-rules" }
 androidx-test-core-ktx = { module = "androidx.test:core-ktx", version.ref = "androidx-test-core" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso-intents" }
+espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "espresso" }
+androidx-espresso-contrib = { group = "androidx.test.espresso", name = "espresso-contrib", version.ref = "espresso" }
+espresso-idling-resource = { module = "androidx.test.espresso:espresso-idling-resource", version.ref = "espresso" }
 okhttp3-idling-resource = { module = "com.jakewharton.espresso:okhttp3-idling-resource", version.ref = "okhttp3-idling-resource" }
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidx-arch-core-testing" }
 junit = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
The user reported a build failure after adding 'espresso-contrib' to their Version Catalog. The root cause was that the library declaration referenced a version key ('espresso') that was not defined in the catalog's '[versions]' block (the existing key was 'espresso-core').

I resolved this by:
1. Renaming the version key 'espresso-core' to 'espresso' in 'gradle/libs.versions.toml'.
2. Updating all Espresso library declarations to use this new 'espresso' reference.
3. Adding the requested 'androidx-espresso-contrib' library.
4. Adding 'espresso-idling-resource' for completeness.
5. Updating 'app/build.gradle.kts' to include these new dependencies and removing a duplicate 'espresso-core' entry.

The build was verified using './gradlew help' and './gradlew :app:assembleEntourageStagingDebugAndroidTest'.

---
*PR created automatically by Jules for task [11906433343148944511](https://jules.google.com/task/11906433343148944511) started by @FrPellissier*