### PR TITLE
Add deep links for Good Waves, Event Creation, and Solidarity Chat

### DIFF
--- a/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
+++ b/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
@@ -131,8 +131,19 @@ class UniversalLinkManager(val context:Context):UniversalLinksPresenterCallback 
                     }
                     (context as Activity).startActivity(intent)
                 }
+                pathSegments.contains("good-waves") -> {
+                    val intent = Intent(context, social.entourage.android.small_talks.SmallTalkIntroActivity::class.java)
+                    context.startActivity(intent)
+                }
                 pathSegments.contains("outings") -> {
-                    if (pathSegments.size > 3) {
+                    if (pathSegments.contains("papotages")) {
+                        presenter.getEventSmallTalk()
+                    } else if (pathSegments.contains("new")) {
+                        val intent = Intent(context, social.entourage.android.events.create.CreateEventActivity::class.java)
+                        (context as? MainActivity)?.startActivityForResult(intent, 0)
+                    } else if (pathSegments.contains("webinar")) {
+                        //Do nothing for now
+                    } else if (pathSegments.size > 3) {
                         val outingId = pathSegments[2]
                         EventFeedFragment.shouldAddToAgenda = true
                         presenter.getEvent(outingId)

--- a/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
+++ b/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
@@ -131,7 +131,7 @@ class UniversalLinkManager(val context:Context):UniversalLinksPresenterCallback 
                     }
                     (context as Activity).startActivity(intent)
                 }
-                pathSegments.contains("good-waves") -> {
+                pathSegments.contains("smalltalk") -> {
                     val intent = Intent(context, social.entourage.android.small_talks.SmallTalkIntroActivity::class.java)
                     context.startActivity(intent)
                 }

--- a/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkPresenter.kt
+++ b/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkPresenter.kt
@@ -153,6 +153,29 @@ class UniversalLinkPresenter(val callback:UniversalLinksPresenterCallback) {
                 }
             })
     }
+
+    fun getEventSmallTalk() {
+        EntourageApplication.get().apiModule.eventsRequest.getEventSmallTalk()
+            .enqueue(object : Callback<EventWrapper> {
+                override fun onResponse(
+                    call: Call<EventWrapper>,
+                    response: Response<EventWrapper>
+                ) {
+                    if (response.isSuccessful) {
+                        response.body()?.let { eventWrapper ->
+                            callback.onRetrievedEvent(eventWrapper.event)
+                        }
+                    }
+                    if(response.code() >= 400){
+                        callback.onErrorRetrievedEvent()
+                    }
+                }
+
+                override fun onFailure(call: Call<EventWrapper>, t: Throwable) {
+                    callback.onErrorRetrievedEvent()
+                }
+            })
+    }
 }
 
 interface UniversalLinksPresenterCallback{


### PR DESCRIPTION
Implemented deep link handling for "Bonnes ondes" (SmallTalk), Event Creation funnel, and Solidarity Chat (papotages). Also added a placeholder for Webinars.

Changes:
1.  **UniversalLinkPresenter.kt**: Added `getEventSmallTalk()` which calls the corresponding API endpoint.
2.  **UniversalLinkManager.kt**:
    - Added handling for `good-waves` path segment to launch `SmallTalkIntroActivity`.
    - Modified `outings` path handling to detect `papotages`, `new`, and `webinar` keywords before checking for event IDs.
    - `papotages` triggers `getEventSmallTalk`.
    - `new` triggers `CreateEventActivity`.
    - `webinar` is currently a no-op.

---
*PR created automatically by Jules for task [6068108609035159670](https://jules.google.com/task/6068108609035159670) started by @clemPerrousset*