### PR TITLE
feat: Display last message date for discussions and event date for outings

### DIFF
--- a/app/src/main/java/social/entourage/android/api/model/Discussions.kt
+++ b/app/src/main/java/social/entourage/android/api/model/Discussions.kt
@@ -210,7 +210,8 @@ data class ConversationMembership(
     @SerializedName("number_of_root_chat_messages") val numberOfRootMessages: Int?,
     @SerializedName("number_of_unread_messages") val numberOfUnreadMessages: Int?,
     @SerializedName("last_chat_message") val lastChatMessageText: String?,
-    @SerializedName("last_chat_message_image_url") val lastChatMessageImageUrl: String?
+    @SerializedName("last_chat_message_image_url") val lastChatMessageImageUrl: String?,
+    @SerializedName("last_chat_message_datetime") val lastChatMessageDate: String?
 ){
     fun createdDateString(): String {
         subname?.let { dateString ->
@@ -218,7 +219,7 @@ data class ConversationMembership(
                 val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", Locale.US)
                 val parsedDate = inputFormat.parse(dateString)
 
-                val outputFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+                val outputFormat = SimpleDateFormat("d MMMM yyyy", Locale.getDefault())
                 parsedDate?.let { outputFormat.format(it) } ?: ""
             } catch (e: Exception) {
                 ""

--- a/app/src/main/java/social/entourage/android/discussions/DiscussionsListAdapter.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DiscussionsListAdapter.kt
@@ -117,10 +117,13 @@ class DiscussionsListAdapter(
             binding.name.text = nameToDisplay
 
             if (conversation.type == "outing") {
-                binding.date.text = conversation.subname
-                binding.date.visibility = View.VISIBLE
-            } else {
                 binding.date.visibility = View.GONE
+                binding.dateEvent.visibility = View.VISIBLE
+                binding.dateEvent.text = conversation.subname
+            } else {
+                binding.date.visibility = View.VISIBLE
+                binding.dateEvent.visibility = View.GONE
+                binding.date.text = conversation.dateFormattedString(binding.root.context)
             }
 
             // === Rôles ===

--- a/app/src/main/java/social/entourage/android/discussions/DiscussionsMainFragment.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DiscussionsMainFragment.kt
@@ -384,8 +384,23 @@ class DiscussionsMainFragment : Fragment() {
     }
 
     private fun membershipToConversation(m: ConversationMembership): Conversation {
+        var date:java.util.Date? = null
+        m.lastChatMessageDate?.let {
+            try {
+                val inputFormat = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", java.util.Locale.US)
+                date = inputFormat.parse(it)
+            } catch (e: Exception) {
+                try {
+                    val inputFormat = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.US)
+                    date = inputFormat.parse(it)
+                } catch (e: Exception) {
+                    Timber.e(e)
+                }
+            }
+        }
+
         val lastMessage = if (m.lastChatMessageText != null || m.lastChatMessageImageUrl != null) {
-            LastMessage(m.lastChatMessageText, null, m.lastChatMessageImageUrl)
+            LastMessage(m.lastChatMessageText, date, m.lastChatMessageImageUrl)
         } else {
             null
         }

--- a/app/src/main/res/layout/layout_conversation_home_item.xml
+++ b/app/src/main/res/layout/layout_conversation_home_item.xml
@@ -88,7 +88,6 @@
                 style="@style/left_legend_grey"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/black"
                 android:textAlignment="viewStart"
                 android:textSize="13sp"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Implemented the requirement to display the last message date for private and small-talk discussions, and the event date for outings in the discussion list.
- For outings: The event date is displayed in grey under the title.
- For others: The last message date is displayed on the right.
- Handled API response changes including the new `last_chat_message_datetime` field.

---
*PR created automatically by Jules for task [14852654481927163799](https://jules.google.com/task/14852654481927163799) started by @clemPerrousset*