### PR TITLE
feat: Add webinar deeplink support

### DIFF
--- a/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
+++ b/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
@@ -112,6 +112,9 @@ interface EventsRequest {
     @GET("outings/smalltalk")
     fun getEventSmallTalk(): Call<EventWrapper>
 
+    @GET("outings/sensibilisation")
+    fun getEventSensibilisation(): Call<EventWrapper>
+
     @POST("outings/{event_id}/users")
     fun participate(
         @Path("event_id") eventId: Int

--- a/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
+++ b/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
@@ -142,7 +142,7 @@ class UniversalLinkManager(val context:Context):UniversalLinksPresenterCallback 
                         val intent = Intent(context, social.entourage.android.events.create.CreateEventActivity::class.java)
                         (context as? MainActivity)?.startActivityForResult(intent, 0)
                     } else if (pathSegments.contains("webinar")) {
-                        //Do nothing for now
+                        presenter.getEventSensibilisation()
                     } else if (pathSegments.size > 3) {
                         val outingId = pathSegments[2]
                         EventFeedFragment.shouldAddToAgenda = true

--- a/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkPresenter.kt
+++ b/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkPresenter.kt
@@ -176,6 +176,29 @@ class UniversalLinkPresenter(val callback:UniversalLinksPresenterCallback) {
                 }
             })
     }
+
+    fun getEventSensibilisation() {
+        EntourageApplication.get().apiModule.eventsRequest.getEventSensibilisation()
+            .enqueue(object : Callback<EventWrapper> {
+                override fun onResponse(
+                    call: Call<EventWrapper>,
+                    response: Response<EventWrapper>
+                ) {
+                    if (response.isSuccessful) {
+                        response.body()?.let { eventWrapper ->
+                            callback.onRetrievedEvent(eventWrapper.event)
+                        }
+                    }
+                    if(response.code() >= 400){
+                        callback.onErrorRetrievedEvent()
+                    }
+                }
+
+                override fun onFailure(call: Call<EventWrapper>, t: Throwable) {
+                    callback.onErrorRetrievedEvent()
+                }
+            })
+    }
 }
 
 interface UniversalLinksPresenterCallback{

--- a/app/src/main/java/social/entourage/android/events/EventsPresenter.kt
+++ b/app/src/main/java/social/entourage/android/events/EventsPresenter.kt
@@ -364,6 +364,27 @@ class EventsPresenter : ViewModel() {
             })
     }
 
+    fun getEventSensibilisation() {
+        EntourageApplication.get().apiModule.eventsRequest.getEventSensibilisation()
+            .enqueue(object : Callback<EventWrapper> {
+                override fun onResponse(
+                    call: Call<EventWrapper>,
+                    response: Response<EventWrapper>
+                ) {
+                    if (response.isSuccessful) {
+                        response.body()?.let { eventWrapper ->
+                            getEvent.value = eventWrapper.event
+                        }
+                    }
+
+                }
+
+                override fun onFailure(call: Call<EventWrapper>, t: Throwable) {
+                    Timber.wtf("wtf error " + t.message)
+                }
+            })
+    }
+
     fun participate(eventId: Int) {
         EntourageApplication.get().apiModule.eventsRequest.participate(eventId)
             .enqueue(object : Callback<EntourageUserResponse> {


### PR DESCRIPTION
This PR adds support for the `webinar` deeplink keyword. When a user clicks a link containing `/outings/webinar`, the app will now fetch the corresponding "sensibilisation" event from the API endpoint `/api/v1/outings/sensibilisation` and display it, similar to how "papotage" (SmallTalk) events are handled.

Changes:
- Added `getEventSensibilisation` to `EventsRequest.kt`.
- Added `getEventSensibilisation` to `UniversalLinkPresenter.kt` and `EventsPresenter.kt`.
- Updated `UniversalLinkManager.kt` to route `webinar` path segments to the new presenter method.

---
*PR created automatically by Jules for task [12949141425799414357](https://jules.google.com/task/12949141425799414357) started by @clemPerrousset*