### PR TITLE
Handle 'birthday' stage for in-app and push notifications

### DIFF
--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -42,6 +42,7 @@ import social.entourage.android.databinding.ActivityMainBinding
 import social.entourage.android.deeplinks.UniversalLinkManager
 import social.entourage.android.events.EventsPresenter
 import social.entourage.android.guide.GDSMainActivity
+import social.entourage.android.home.BirthdayActivity
 import social.entourage.android.home.CommunicationHandlerBadgeViewModel
 import social.entourage.android.home.EventConfirmationDialogFragment
 import social.entourage.android.home.UnreadMessages
@@ -315,7 +316,15 @@ class MainActivity : BaseSecuredActivity() {
         val goDemand = intent.getBooleanExtra("goDemand", false)
         val goDiscoverGroup = intent.getBooleanExtra("goDiscoverGroup", false)
         val goDiscoverEvent = intent.getBooleanExtra("goDiscoverEvent", false)
+        val goBirthday = intent.getBooleanExtra("goBirthday", false)
 
+
+        if (goBirthday) {
+            intent.removeExtra("goBirthday")
+            goHome()
+            startActivity(Intent(this, BirthdayActivity::class.java))
+            return
+        }
 
         if (goContrib) {
             intent.removeExtra("goContrib")
@@ -390,6 +399,7 @@ class MainActivity : BaseSecuredActivity() {
                         instance,
                         extra.instanceId ?: 0,
                         extra.postId,
+                        stage = extra.stage,
                         popup = extra.popup,
                         tracking = extra.tracking
                     )

--- a/app/src/main/java/social/entourage/android/notifications/NotificationActionManager.kt
+++ b/app/src/main/java/social/entourage/android/notifications/NotificationActionManager.kt
@@ -24,6 +24,7 @@ import social.entourage.android.welcome.WelcomeFourActivity
 import social.entourage.android.welcome.WelcomeOneActivity
 import social.entourage.android.welcome.WelcomeThreeActivity
 import social.entourage.android.welcome.WelcomeTwoActivity
+import social.entourage.android.home.BirthdayActivity
 
 /**
  * Created by Me on 26/09/2022.
@@ -32,6 +33,19 @@ object NotificationActionManager {
 
     /**/
     fun presentAction(context:Context,supportFragmentManager: FragmentManager, instance:String, id:Int = 0, postId:Int?, stage:String? = "", popup:String? = "" , notifContext:String? = "", tracking:String? = ""){
+        if (stage == "birthday") {
+            if (context is MainActivity) {
+                (context as MainActivity).goHome()
+                context.startActivity(Intent(context, BirthdayActivity::class.java))
+            } else {
+                val intent = Intent(context, MainActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                intent.putExtra("goBirthday", true)
+                context.startActivity(intent)
+            }
+            return
+        }
+
         if(popup.equals("outing_on_day_before")){
             if(context is MainActivity){
                 (context as MainActivity).ifEventLastDay(id)


### PR DESCRIPTION
- Update `MainActivity` to pass the `stage` field from the push notification payload to `NotificationActionManager.presentAction`.
- Implement navigation logic in `NotificationActionManager` to handle the "birthday" stage:
  - If the context is `MainActivity`, navigate to the Home tab and open `BirthdayActivity`.
  - If the context is not `MainActivity`, launch `MainActivity` with `CLEAR_TOP` and a `goBirthday` extra to trigger the same flow.
- Add `goBirthday` handling in `MainActivity.useIntentForRedictection`.

---
*PR created automatically by Jules for task [14095264031304566262](https://jules.google.com/task/14095264031304566262) started by @clemPerrousset*