### PR TITLE
Fix: Use correct SmallTalk ID when leaving a conversation

### DIFF
--- a/app/src/main/java/social/entourage/android/report/ActionSheetFragment.kt
+++ b/app/src/main/java/social/entourage/android/report/ActionSheetFragment.kt
@@ -485,7 +485,7 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
                             getString(R.string.leave_conversation_dialog_content),
                             getString(R.string.exit)
                         ) {
-                            smallTalkViewModel.leaveSmallTalk(conversationId.toString())
+                            smallTalkViewModel.leaveSmallTalk(DetailConversationActivity.smallTalkId)
                             dismiss()
                         }
                     } else {


### PR DESCRIPTION
The ActionSheetFragment was attempting to use the integer `conversationId` (which defaults to 0 for SmallTalks) when calling `leaveSmallTalk`. This commit changes it to use the correct `DetailConversationActivity.smallTalkId` (which is a UUID string) when in SmallTalk mode, ensuring the correct conversation is targeted.

---
*PR created automatically by Jules for task [13195284906792341153](https://jules.google.com/task/13195284906792341153) started by @clemPerrousset*