### PR TITLE
Update SmallTalk wording on Home screen for all languages

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -2759,4 +2759,6 @@
     <string name="onboard_sms_wait_countdown">يمكنك طلب رمز جديد خلال %1$s</string>
 
     <string name="guide_help_orientation_button">المساعدة والتوجيه</string>
+    <string name="home_title_small_talk">انضم إلى نقاش تضامني</string>
+    <string name="small_talk_subtitle_match">نصلك بمجموعة صغيرة من الأشخاص الذين يشاركونك اهتماماتك، في كل مكان في فرنسا.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2721,4 +2721,6 @@ Sie werden diese Nachricht lesen, sobald sie der Gruppe beitreten.</string>
     <string name="onboard_sms_wait_countdown">Du kannst in %1$s einen neuen Code anfordern</string>
 
     <string name="guide_help_orientation_button">Hilfe &amp; Orientierung</string>
+    <string name="home_title_small_talk">Einer solidarischen Diskussion beitreten</string>
+    <string name="small_talk_subtitle_match">Wir verbinden dich mit einer kleinen Gruppe von Menschen, die deine Interessen teilen, überall in Frankreich.</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1861,4 +1861,6 @@
 
 
     <string name="guide_help_orientation_button">Help &amp; orientation</string>
+    <string name="home_title_small_talk">Join a solidarity discussion</string>
+    <string name="small_talk_subtitle_match">We connect you with a small group of people who share your interests, anywhere in France.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -2718,4 +2718,6 @@ Leerán este mensaje tan pronto como se unan al grupo.</string>
     <string name="onboard_sms_wait_countdown">Podrás solicitar un nuevo código en %1$s</string>
 
     <string name="guide_help_orientation_button">Ayuda y orientación</string>
+    <string name="home_title_small_talk">Unirse a una discusión solidaria</string>
+    <string name="small_talk_subtitle_match">Te ponemos en contacto con un pequeño grupo de personas que comparten tus intereses, en toda Francia.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -2735,4 +2735,6 @@ Przeczytają tę wiadomość, gdy tylko dołączą do grupy.</string>
     <string name="onboard_sms_wait_countdown">Nowy kod będziesz mógł/mogła zamówić za %1$s</string>
 
     <string name="guide_help_orientation_button">Pomoc i orientacja</string>
+    <string name="home_title_small_talk">Dołącz do dyskusji solidarnościowej</string>
+    <string name="small_talk_subtitle_match">Łączymy Cię z małą grupą osób, które dzielą Twoje zainteresowania, w całej Francji.</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -2733,4 +2733,6 @@ Ei vor citi acest mesaj imediat ce se vor alătura grupului.</string>
 
 
     <string name="guide_help_orientation_button">Ajutor și orientare</string>
+    <string name="home_title_small_talk">Alătură-te unei discuții solidare</string>
+    <string name="small_talk_subtitle_match">Te punem în legătură cu un grup mic de persoane care îți împărtășesc interesele, oriunde în Franța.</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -2646,4 +2646,6 @@
     <string name="onboard_sms_wait_countdown">Ви зможете запросити новий код через %1$s</string>
 
     <string name="guide_help_orientation_button">Допомога та орієнтація</string>
+    <string name="home_title_small_talk">Приєднатися до солідарної дискусії</string>
+    <string name="small_talk_subtitle_match">Ми з'єднуємо вас з невеликою групою людей, які поділяють ваші інтереси, по всій Франції.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3045,8 +3045,8 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="small_talk_group_found_subtitle">Découvrez les personnes de votre groupe</string>
 
     <!-- Accueil -->
-    <string name="home_title_small_talk">Partager des « Bonnes Ondes » !</string>
-    <string name="small_talk_subtitle_match">Découvrez un nouveau moyen de discuter et de créer des liens qui durent dans le temps !</string>
+    <string name="home_title_small_talk">Rejoindre une discussion solidaire</string>
+    <string name="small_talk_subtitle_match">On vous met en relation avec un petit groupe de personnes qui partagent vos centres d’intérêt, partout en France.</string>
     <string name="small_talk_button_match">Discuter</string>
     <string name="small_talk_title_waiting">Bientôt de nouvelles rencontres</string>
     <string name="small_talk_subtitle_waiting">On vous prévient dès qu\'on a trouvé des gens qui sont sur la même longueur d\'onde ;)</string>


### PR DESCRIPTION
- Replaced "Partager des Bonnes Ondes !" with "Rejoindre une discussion solidaire" in French (default).
- Replaced the description with "On vous met en relation avec un petit groupe de personnes qui partagent vos centres d’intérêt, partout en France."
- Added/Updated translations for English, German, Spanish, Polish, Romanian, Ukrainian, and Arabic to ensure consistent localization.

---
*PR created automatically by Jules for task [6609047316094464168](https://jules.google.com/task/6609047316094464168) started by @clemPerrousset*