### PR TITLE
Fix leaving smalltalk conversation failure

### DIFF
--- a/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
@@ -221,7 +221,7 @@ class DetailConversationActivity : CommentActivity() {
             // On passe TOUS les arguments nécessaires (comme dans EventFeedFragment)
             ActionSheetFragment.newEvent(
                 eventId = eventId,
-                conversationId = id,
+                conversationId = if (isSmallTalkMode) smallTalkId.toIntOrNull() ?: 0 else id,
                 canManageParticipants = false, // À adapter selon ta logique métier
                 eventTitle = event?.title ?: "",
                 participantsCount = event?.membersCount ?: 0,
@@ -236,7 +236,7 @@ class DetailConversationActivity : CommentActivity() {
                         ?.firstOrNull { it?.id != EntourageApplication.get().me()?.id }
                         ?.id ?: 0
                     ActionSheetFragment.newDiscussion(
-                        conversationId = id,
+                        conversationId = if (isSmallTalkMode) smallTalkId.toIntOrNull() ?: 0 else id,
                         isOneToOne = true,
                         userId = otherUserId,
                         username = detailConversation?.title,
@@ -245,7 +245,7 @@ class DetailConversationActivity : CommentActivity() {
                 }
                 SheetMode.DISCUSSION_GROUP -> {
                     ActionSheetFragment.newDiscussion(
-                        conversationId = id,
+                        conversationId = if (isSmallTalkMode) smallTalkId.toIntOrNull() ?: 0 else id,
                         isOneToOne = false,
                         userId = 0,
                         username = null,


### PR DESCRIPTION
Fix issue where leaving a smalltalk conversation failed.

The issue was caused by `DetailConversationActivity` passing `id` (0) instead of `smallTalkId` when creating `ActionSheetFragment` for SmallTalk conversations. `Const.ID` was missing from the launch intent, causing `id` to be default (0).

Modified `DetailConversationActivity.buildAndShowActionSheet` to use `smallTalkId` (parsed to Int) when `isSmallTalkMode` is true, ensuring the correct ID is passed to `ActionSheetFragment` and subsequently to the `leaveSmallTalk` API call.

---
*PR created automatically by Jules for task [8347470935579772566](https://jules.google.com/task/8347470935579772566) started by @clemPerrousset*