### PR TITLE
🧪 Unit tests for LanguageManager.mapLanguageToCode

### DIFF
--- a/app/src/test/java/social/entourage/android/language/LanguageManagerTest.kt
+++ b/app/src/test/java/social/entourage/android/language/LanguageManagerTest.kt
@@ -1,0 +1,25 @@
+package social.entourage.android.language
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LanguageManagerTest {
+
+    @Test
+    fun `mapLanguageToCode returns correct code for all mapped languages`() {
+        LanguageManager.languageMap.forEach { (name, code) ->
+            assertEquals("Language $name should map to code $code", code, LanguageManager.mapLanguageToCode(name))
+        }
+    }
+
+    @Test
+    fun `mapLanguageToCode returns fr for unknown language`() {
+        val unknownLanguage = "Unknown"
+        assertEquals("fr", LanguageManager.mapLanguageToCode(unknownLanguage))
+    }
+
+    @Test
+    fun `mapLanguageToCode returns fr for empty string`() {
+        assertEquals("fr", LanguageManager.mapLanguageToCode(""))
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was the untested `LanguageManager.mapLanguageToCode` utility function.
📊 **Coverage:** The new tests cover:
- All languages currently defined in `LanguageManager.languageMap` (Français, English, Deutsch, Español, Polski, Українська, Română, العربية).
- The default fallback to "fr" for unknown languages.
- The edge case of an empty language string.
✨ **Result:** Increased reliability of the language selection logic and better test coverage for utility functions.

---
*PR created automatically by Jules for task [13756532931148448379](https://jules.google.com/task/13756532931148448379) started by @clemPerrousset*