### PR TITLE
🔒 [security fix] Fix insecure HTTP URL construction

### DIFF
--- a/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
+++ b/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
@@ -191,7 +191,7 @@ object Utils {
 
     fun checkUrlWithHttps(url: String): String {
         return if ((url.startsWith(Const.HTTP)).not() && (url.startsWith(Const.HTTPS)).not())
-            Const.HTTP + url
+            Const.HTTPS + url
         else url
     }
 


### PR DESCRIPTION
### 🎯 What:
Fixed an insecure HTTP URL construction vulnerability in `Utils.checkUrlWithHttps`.

### ⚠️ Risk:
The code was promoting insecure connections by defaulting to `http://` when a URL lacked a scheme. This could expose users to man-in-the-middle attacks or prevent the app from loading links on devices/networks that enforce HTTPS.

### 🛡️ Solution:
Modified `Utils.checkUrlWithHttps` to use `Const.HTTPS` ("https://") as the default prefix for URLs that don't specify a scheme. Explicit `http://` links are still preserved if already present.

---
*PR created automatically by Jules for task [7263678535104309742](https://jules.google.com/task/7263678535104309742) started by @clemPerrousset*