### PR TITLE
Fix birthday push notification redirection

### DIFF
--- a/app/src/main/java/social/entourage/android/notifications/PushNotificationManager.kt
+++ b/app/src/main/java/social/entourage/android/notifications/PushNotificationManager.kt
@@ -427,6 +427,12 @@ object PushNotificationManager {
             intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
             return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
         }
+        if(pushNotificationMessage.content?.extra?.stage == "birthday"){
+            val intent = Intent(context, MainActivity::class.java)
+            intent.putExtra("goBirthday", true)
+            intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
+            return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
+        }
 
         val instance = pushNotificationMessage.content?.extra?.instance
         val tracking = pushNotificationMessage.content?.extra?.tracking


### PR DESCRIPTION
Fixes an issue where push notifications of type 'birthday' were not redirecting the user correctly. This change aligns the push notification handling with the in-app notification logic by checking for the 'birthday' stage and launching MainActivity with the 'goBirthday' extra.

---
*PR created automatically by Jules for task [3005150298364666286](https://jules.google.com/task/3005150298364666286) started by @clemPerrousset*