### PR TITLE
Fix: Pass SmallTalk context to ActionSheetFragment to allow leaving conversation

### DIFF
--- a/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
@@ -240,7 +240,9 @@ class DetailConversationActivity : CommentActivity() {
                         isOneToOne = true,
                         userId = otherUserId,
                         username = detailConversation?.title,
-                        blocked = detailConversation?.hasBlocker() == true && detailConversation?.imBlocker() == true
+                        blocked = detailConversation?.hasBlocker() == true && detailConversation?.imBlocker() == true,
+                        isSmallTalk = isSmallTalkMode,
+                        smallTalkId = smallTalkId
                     )
                 }
                 SheetMode.DISCUSSION_GROUP -> {
@@ -249,7 +251,9 @@ class DetailConversationActivity : CommentActivity() {
                         isOneToOne = false,
                         userId = 0,
                         username = null,
-                        blocked = false
+                        blocked = false,
+                        isSmallTalk = isSmallTalkMode,
+                        smallTalkId = smallTalkId
                     )
                 }
                 SheetMode.GROUP -> {

--- a/app/src/main/java/social/entourage/android/report/ActionSheetFragment.kt
+++ b/app/src/main/java/social/entourage/android/report/ActionSheetFragment.kt
@@ -59,6 +59,8 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
     private var forceShowEdit: Boolean = false
     private var isEventCreator: Boolean = false
     private var canEditEvent: Boolean = false // NEW: vient de manageable_by_current_user
+    private var isSmallTalk: Boolean = false
+    private var smallTalkId: String? = null
 
     // Message actions
     private var messageId: Int = 0
@@ -86,6 +88,8 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
             eventParticipantsCount = getInt(ARG_EVENT_PARTICIPANTS, 0)
             eventAddress = getString(ARG_EVENT_ADDRESS)
             forceShowEdit = getBoolean(ARG_FORCE_SHOW_EDIT, false)
+            isSmallTalk = getBoolean(ARG_IS_SMALL_TALK, false)
+            smallTalkId = getString(ARG_SMALL_TALK_ID)
 
             messageId = getInt(ARG_MESSAGE_ID, 0)
             messageHtml = getString(ARG_MESSAGE_HTML)
@@ -436,10 +440,19 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
 
                     val isConversationContext = !isEventContext && !isGroupContext
                     if (isConversationContext) {
-                        val isSmallTalk = DetailConversationActivity.isSmallTalkMode
-                        val convOrSmallTalkId =
-                            if (isSmallTalk) DetailConversationActivity.smallTalkId
-                            else conversationId
+                        // Use local isSmallTalk flag if available, fallback to activity static variable only if local flag is false
+                        // Note: In this specific context (Message Actions), we might not have passed isSmallTalk explicitly
+                        // But let's check if we can retrieve it or rely on DetailConversationActivity.isSmallTalkMode
+                        // Since we are modifying ActionSheetFragment to handle this better in general,
+                        // let's try to use the passed argument if possible, but for MessageActions initialized via newMessageActions,
+                        // we might need to add isSmallTalk there too or keep relying on global state for now as the plan focused on newDiscussion.
+                        // However, to be safe and consistent with the fix:
+                        val isSmallTalkMode = isSmallTalk || DetailConversationActivity.isSmallTalkMode
+                        val convOrSmallTalkId = if (isSmallTalkMode) {
+                             smallTalkId ?: DetailConversationActivity.smallTalkId
+                        } else {
+                            conversationId
+                        }
 
                         ReportModalFragment.newInstance(
                             id = convOrSmallTalkId,
@@ -450,7 +463,7 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
                             isOneToOne = false,
                             contentCopied = plain,
                             openDirectSignal = true,
-                            isSmallTalk = isSmallTalk
+                            isSmallTalk = isSmallTalkMode
                         ).show(parentFragmentManager, ReportModalFragment.TAG)
                     } else {
                         val (containerId, rType) = when {
@@ -478,14 +491,14 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
         binding.quit.profileSettingsItemLayout.setOnClickListener {
             when (mode) {
                 SheetMode.DISCUSSION_GROUP -> {
-                    if (DetailConversationActivity.isSmallTalkMode) {
+                    if (isSmallTalk) {
                         CustomAlertDialog.showWithCancelFirst(
                             requireContext(),
                             getString(R.string.leave_conversation),
                             getString(R.string.leave_conversation_dialog_content),
                             getString(R.string.exit)
                         ) {
-                            smallTalkViewModel.leaveSmallTalk(conversationId.toString())
+                            smallTalkViewModel.leaveSmallTalk(smallTalkId.toString())
                             dismiss()
                         }
                     } else {
@@ -598,6 +611,8 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
         private const val ARG_HEADER_FROM_EVENT_FEED = "headerFromEventFeed"
         private const val ARG_IS_EVENT_CREATOR = "isEventCreator"
         private const val ARG_CAN_EDIT_EVENT = "canEditEvent" // NEW
+        private const val ARG_IS_SMALL_TALK = "isSmallTalk"
+        private const val ARG_SMALL_TALK_ID = "smallTalkId"
 
         var isSignable = false
 
@@ -688,7 +703,9 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
             isOneToOne: Boolean,
             userId: Int,
             username: String?,
-            blocked: Boolean
+            blocked: Boolean,
+            isSmallTalk: Boolean = false,
+            smallTalkId: String? = null
         ) = ActionSheetFragment().apply {
             arguments = Bundle().apply {
                 putString(
@@ -700,6 +717,8 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
                 putInt(ARG_USER_ID, userId)
                 putString(ARG_USERNAME, username)
                 putBoolean(ARG_BLOCKED, blocked)
+                putBoolean(ARG_IS_SMALL_TALK, isSmallTalk)
+                putString(ARG_SMALL_TALK_ID, smallTalkId)
             }
         }
     }


### PR DESCRIPTION
Modify `ActionSheetFragment.newDiscussion` to accept `isSmallTalk` and `smallTalkId` arguments.
Store these arguments in `ActionSheetFragment` instance state.
Use `isSmallTalk` and `smallTalkId` in `ActionSheetFragment.setupClicks` for the "Leave Conversation" action, instead of relying on unreliable static variables in `DetailConversationActivity`.
Update `DetailConversationActivity` to pass the local `isSmallTalkMode` and `smallTalkId` when creating the action sheet.

This fixes the issue where `DetailConversationActivity.smallTalkId` or `isSmallTalkMode` could be reset (e.g. after backgrounding), causing the DELETE call to fail with ID -1 or be routed incorrectly.

---
*PR created automatically by Jules for task [12934447565868006387](https://jules.google.com/task/12934447565868006387) started by @clemPerrousset*