### PR TITLE
🧹 [code health] Remove dead code in HomePresenter.kt

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomePresenter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomePresenter.kt
@@ -8,14 +8,12 @@ import retrofit2.Response
 import social.entourage.android.EntourageApplication
 import social.entourage.android.api.model.Action
 import social.entourage.android.api.model.Events
-import social.entourage.android.api.model.Group
 import social.entourage.android.api.request.*
 import social.entourage.android.api.model.notification.InAppNotification
 import social.entourage.android.api.model.notification.InAppNotificationPermission
 import social.entourage.android.api.model.Pedago
 import social.entourage.android.api.model.Summary
 import social.entourage.android.events.list.EVENTS_PER_PAGE
-import social.entourage.android.groups.list.groupPerPage
 
 class HomePresenter: ViewModel() {
     var getSummarySuccess = MutableLiveData<Boolean>()
@@ -32,13 +30,11 @@ class HomePresenter: ViewModel() {
     var notificationsInApp = MutableLiveData<MutableList<InAppNotification>?>()
     var notificationInApp = MutableLiveData<InAppNotification?>()
 
-    //var getAllMyGroups = MutableLiveData<MutableList<Group>>()
     var getAllEvents = MutableLiveData<MutableList<Events>>()
     var getAllActions = MutableLiveData<MutableList<Action>>()
 
     var isLoading: Boolean = false
     var isLastPage: Boolean = false
-    var isLastPageGroup: Boolean = false
     var isLastPageEvent: Boolean = false
     var isLastPageAction: Boolean = false
 
@@ -60,24 +56,6 @@ class HomePresenter: ViewModel() {
                 }
             })
     }
-
-//    fun getMyGroups(page: Int, per: Int, userId: Int) {
-//        EntourageApplication.get().apiModule.groupRequest.getMyGroups(userId, page, per)
-//            .enqueue(object : Callback<GroupsListWrapper> {
-//                override fun onResponse(
-//                    call: Call<GroupsListWrapper>,
-//                    response: Response<GroupsListWrapper>
-//                ) {
-//                    response.body()?.let { allGroupsWrapper ->
-//                        if (allGroupsWrapper.allGroups.size < groupPerPage) isLastPageGroup = true
-//                        getAllMyGroups.value = allGroupsWrapper.allGroups
-//                    }
-//                }
-//
-//                override fun onFailure(call: Call<GroupsListWrapper>, t: Throwable) {
-//                }
-//            })
-//    }
 
     fun getAllEvents(page: Int, per: Int,distance:Int?,latitude:Double?,longitude:Double?,period:String) {
         EntourageApplication.get().apiModule.eventsRequest.getAllEvents(page, per,distance,latitude,longitude,period)


### PR DESCRIPTION
The task was to remove dead code in `HomePresenter.kt`.
I identified the commented-out `getMyGroups` function and its associated properties (`getAllMyGroups`, `isLastPageGroup`) and imports (`Group`, `groupPerPage`).
Grep confirmed that these properties were not used anywhere else in the codebase except within the commented-out sections of `HomePresenter.kt`.
Static analysis was used to verify the changes since the environment limitations prevent running Gradle tests.

---
*PR created automatically by Jules for task [7197182055068148334](https://jules.google.com/task/7197182055068148334) started by @clemPerrousset*