### PR TITLE
⚡ Performance: Cache POI Marker Bitmaps in PoiRenderer

### DIFF
--- a/app/src/main/java/social/entourage/android/guide/poi/PoiRenderer.kt
+++ b/app/src/main/java/social/entourage/android/guide/poi/PoiRenderer.kt
@@ -3,19 +3,33 @@ package social.entourage.android.guide.poi
 import android.content.Context
 import android.graphics.Color
 import androidx.appcompat.content.res.AppCompatResources
+import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.MarkerOptions
+import java.util.concurrent.ConcurrentHashMap
 import social.entourage.android.R
 import social.entourage.android.api.model.BaseEntourage
 import social.entourage.android.api.model.guide.Poi
 import social.entourage.android.tools.utils.Utils
 
 class PoiRenderer {
+    companion object {
+        private val iconsCache = ConcurrentHashMap<Int, BitmapDescriptor>()
+    }
+
     // ----------------------------------
     // PUBLIC METHODS
     // ----------------------------------
     fun getMarkerOptions(poi: Poi, context: Context): MarkerOptions? {
-        val drawable = AppCompatResources.getDrawable(context, categoryForCategoryId(poi.categoryId).resourceId) ?: return null
-        val icon = Utils.getBitmapDescriptorFromDrawable(drawable, BaseEntourage.getMarkerSize(context), BaseEntourage.getMarkerSize(context))
+        val resourceId = categoryForCategoryId(poi.categoryId).resourceId
+
+        val icon = iconsCache[resourceId] ?: run {
+            val drawable = AppCompatResources.getDrawable(context, resourceId) ?: return null
+            val size = BaseEntourage.getMarkerSize(context)
+            val newIcon = Utils.getBitmapDescriptorFromDrawable(drawable, size, size)
+            iconsCache[resourceId] = newIcon
+            newIcon
+        }
+
         return MarkerOptions()
                 .position(poi.position)
                 .title(poi.title)


### PR DESCRIPTION
This PR introduces a performance optimization for map marker rendering in the POI guide. 

Currently, `PoiRenderer.getMarkerOptions` creates a new `BitmapDescriptor` for every POI displayed on the map. This process involves multiple expensive steps: loading a drawable, creating a bitmap, rendering the drawable into the bitmap, potentially scaling the bitmap, and finally creating a `BitmapDescriptor`. For a map with hundreds of POIs, this results in significant CPU and memory overhead.

The optimization implements a static cache (`iconsCache`) within `PoiRenderer`. Since there are only 15 POI categories, we now only perform these expensive operations once per category resource. 

Key changes:
- Added a `companion object` to `PoiRenderer` with a `ConcurrentHashMap<Int, BitmapDescriptor>`.
- Updated `getMarkerOptions` to check the cache before creating a new icon.
- Ensured thread safety and preserved existing null-handling logic.

Performance impact:
- CPU: Significant reduction in rendering time when many markers are added to the map.
- Memory: Reduced temporary bitmap allocations during marker creation.

---
*PR created automatically by Jules for task [18355281961882454316](https://jules.google.com/task/18355281961882454316) started by @clemPerrousset*