### PR TITLE
fix(EventFeedFragment): update event date format to long format

### DIFF
--- a/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
@@ -309,12 +309,7 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
                 )
             }
             event?.metadata?.startsAt?.let {
-                binding.dateStartsAt.content.text = SimpleDateFormat(
-                    context?.getString(R.string.feed_event_date),
-                    locale
-                ).format(
-                    it
-                )
+                binding.dateStartsAt.content.text = Utils.formatEventDateLong(it, requireContext())
             }
             event?.metadata?.startsAt?.let {
                 binding.time.content.text = SimpleDateFormat(


### PR DESCRIPTION
This change updates the date format in `EventFeedFragment` (the event detail view) to use the long format (e.g., "Vendredi 11 Janvier") instead of the previous "11 Janvier 2024" format. This aligns the display with other screens like `AboutEventFragment` by utilizing the standard `Utils.formatEventDateLong` helper method.

- **File Modified**: `app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt`
- **Change**: Replaced manual `SimpleDateFormat` with `Utils.formatEventDateLong(it, requireContext())`.
- **Reason**: User request for consistent date formatting across the app.

---
*PR created automatically by Jules for task [13109093710895409962](https://jules.google.com/task/13109093710895409962) started by @clemPerrousset*