### PR TITLE
Refactor Notification Navigation to NotificationRouter

### DIFF
--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -47,6 +47,8 @@ import social.entourage.android.home.CommunicationHandlerBadgeViewModel
 import social.entourage.android.home.EventConfirmationDialogFragment
 import social.entourage.android.home.UnreadMessages
 import social.entourage.android.language.LanguageManager
+import social.entourage.android.notifications.NotificationRouter
+import social.entourage.android.notifications.PushNotificationManager
 import social.entourage.android.main_filter.MainFilterActivity
 import social.entourage.android.notifications.NotificationActionManager
 import social.entourage.android.notifications.PushNotificationManager
@@ -384,28 +386,32 @@ class MainActivity : BaseSecuredActivity() {
                 NotificationManagerCompat.from(this).areNotificationsEnabled()
             )
         }
-    }
-
     private fun checkIntentAction(action: String, extras: Bundle?) {
-        extras?.getString(PushNotificationManager.KEY_CONTENT)?.let { rawContent ->
-            Gson().fromJson(
-                rawContent,
-                PushNotificationContent::class.java
-            )?.extra?.let { extra ->
-                extra.instance?.let { instance ->
-                    NotificationActionManager.presentAction(
-                        this,
-                        supportFragmentManager,
-                        instance,
-                        extra.instanceId ?: 0,
-                        extra.postId,
-                        stage = extra.stage,
-                        popup = extra.popup,
-                        tracking = extra.tracking
+        if (extras == null) return
+        var contentJson = extras.getString("notification_content")
+        if (contentJson == null) {
+            contentJson = extras.getString(PushNotificationManager.KEY_CONTENT)
+        }
+        if (contentJson != null) {
+            try {
+                val content = Gson().fromJson(contentJson, PushNotificationContent::class.java)
+                if (content != null) {
+                    val extra = content.extra
+                    val args = NotificationRouter.NotificationArguments(
+                        instance = extra?.instance,
+                        id = extra?.instanceId ?: extra?.joinableId?.toInt() ?: 0,
+                        postId = extra?.postId,
+                        stage = extra?.stage,
+                        popup = extra?.popup,
+                        tracking = extra?.tracking,
+                        contentJson = contentJson
                     )
+                    NotificationRouter.navigate(this, supportFragmentManager, args)
                 }
+            } catch (e: Exception) {
+                Timber.e(e)
             }
-        }?: Timber.d("wtf notif :extras null")
+        }
         intent = null
     }
 

--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -47,10 +47,8 @@ import social.entourage.android.home.CommunicationHandlerBadgeViewModel
 import social.entourage.android.home.EventConfirmationDialogFragment
 import social.entourage.android.home.UnreadMessages
 import social.entourage.android.language.LanguageManager
-import social.entourage.android.notifications.NotificationRouter
-import social.entourage.android.notifications.PushNotificationManager
 import social.entourage.android.main_filter.MainFilterActivity
-import social.entourage.android.notifications.NotificationActionManager
+import social.entourage.android.notifications.NotificationRouter
 import social.entourage.android.notifications.PushNotificationManager
 import social.entourage.android.profile.MyProfileFullActivity
 import social.entourage.android.tools.TestHelper
@@ -386,6 +384,8 @@ class MainActivity : BaseSecuredActivity() {
                 NotificationManagerCompat.from(this).areNotificationsEnabled()
             )
         }
+    }
+
     private fun checkIntentAction(action: String, extras: Bundle?) {
         if (extras == null) return
         var contentJson = extras.getString("notification_content")

--- a/app/src/main/java/social/entourage/android/notifications/NotificationActionManager.kt
+++ b/app/src/main/java/social/entourage/android/notifications/NotificationActionManager.kt
@@ -27,168 +27,36 @@ import social.entourage.android.welcome.WelcomeTwoActivity
 import social.entourage.android.home.BirthdayActivity
 
 /**
- * Created by Me on 26/09/2022.
+ * Delegating wrapper for NotificationRouter.
+ * Maintained for backward compatibility with In-App Notifications.
  */
 object NotificationActionManager {
 
-    /**/
-    fun presentAction(context:Context,supportFragmentManager: FragmentManager, instance:String, id:Int = 0, postId:Int?, stage:String? = "", popup:String? = "" , notifContext:String? = "", tracking:String? = ""){
-
-        if(popup.equals("outing_on_day_before")){
-            if(context is MainActivity){
-                (context as MainActivity).ifEventLastDay(id)
-                return
-            }
-            else{
-                MainActivity.shouldLaunchEventPopUp = id
-                (context as Activity).finish()
-                return
-            }
-        }
-        if(notifContext.equals("outing_on_day_before")){
-            if(context is MainActivity){
-                (context as MainActivity).ifEventLastDay(id)
-                return
-
-            }else{
-                MainActivity.shouldLaunchEventPopUp = id
-                (context as Activity).finish()
-                return
-            }
-        }
-
-        if(!stage.isNullOrEmpty()){
-
-            if(stage.equals("h1")){
-                val intent = Intent(context, WelcomeOneActivity::class.java)
-                context.startActivity(intent)
-            }
-            if(stage.equals("j2")){
-                val intent = Intent(context, WelcomeTwoActivity::class.java)
-                context.startActivity(intent)
-            }
-            if(stage.equals("j5")){
-                val intent = Intent(context, WelcomeThreeActivity::class.java)
-                context.startActivity(intent)
-            }
-            if(stage.equals("j8")){
-                val intent = Intent(context, WelcomeFourActivity::class.java)
-                context.startActivity(intent)
-            }
-            if(stage.equals("j11")){
-                val intent = Intent(context, WelcomeFiveActivity::class.java)
-                context.startActivity(intent)
-            }
-        }
-
-
-        Log.wtf("wtf", "instance from NotificationActionManager: $instance")
-        Log.wtf("wtf", "tracking: from NotificationActionManager$tracking")
-        Log.wtf("wtf", "id: from NotificationActionManager$id")
-
-        // Cas spécifiques : si c'est un outing ET que le tracking correspond à une conversation
-        val validTracking = listOf(
-            "public_chat_message_on_create",
-            "post_on_create_to_outing",
-            "post_on_create",
-            "comment_on_create_to_outing",
-            "comment_on_create",
-            "chat_message_on_mention",
-            "reaction_on_create",
-            "survey_response_on_create"
+    fun presentAction(context: Context, supportFragmentManager: FragmentManager, instance: String, id: Int = 0, postId: Int? = null, stage: String? = "", popup: String? = "", notifContext: String? = "", tracking: String? = "") {
+        val args = NotificationRouter.NotificationArguments(
+            instance = instance,
+            id = id,
+            postId = postId,
+            stage = stage,
+            popup = popup,
+            notifContext = notifContext,
+            tracking = tracking
         )
-
-        if ((instance == "outings" || instance == "outing") && (notifContext in validTracking || tracking in validTracking)) {
-            Log.wtf("wtf", "➡️ Redirection discussion/outing via notifContext = $notifContext")
-            context.startActivity(
-                Intent(context, DetailConversationActivity::class.java).apply {
-                    putExtras(
-                        bundleOf(
-                            Const.ID to id,
-                            Const.SHOULD_OPEN_KEYBOARD to false,
-                            Const.IS_CONVERSATION_1TO1 to true,
-                            Const.IS_MEMBER to true,
-                            Const.IS_CONVERSATION to true,
-                            Const.HAS_TO_SHOW_MESSAGE to true
-                        )
-                    )
-                }
-            )
-            return
-        }
-
-        when(getInstanceTypeFromName(instance)) {
-            InstanceType.POIS -> showPoi(supportFragmentManager,id)
-            InstanceType.USERS -> showUser(context,supportFragmentManager,id)
-            InstanceType.NEIGHBORHOODS -> showNeighborhood(context,supportFragmentManager,id)
-            InstanceType.RESOURCES -> showResource(context,supportFragmentManager,id)
-            InstanceType.OUTINGS -> showOuting(context,supportFragmentManager,id)
-            InstanceType.OUTINGS_MESSAGE -> showConversation(context,supportFragmentManager,id)
-            InstanceType.CONTRIBUTIONS -> showContribution(context,supportFragmentManager,id)
-            InstanceType.SOLICITATIONS -> showSolicitation(context,supportFragmentManager,id)
-            InstanceType.CONVERSATIONS -> showConversation(context,supportFragmentManager,id)
-            InstanceType.SMALLTALK -> showSmallTalk(context,supportFragmentManager,id)
-            InstanceType.AlMOSTMATCH -> showAlmostMatch(context,supportFragmentManager,id)
-            InstanceType.PARTNERS -> showPartner(context,id)
-            InstanceType.NONE -> return
-
-            else -> {
-                if(getInstanceTypeFromName(instance) == InstanceType.OUTING_POSTS){
-                    if (postId != null) {
-                        showEventPost(context,supportFragmentManager,id,postId)
-                    }
-                } else if(getInstanceTypeFromName(instance) == InstanceType.NEIGHBORHOODS_POSTS){
-                    if (postId != null) {
-                        showGroupPost(context,supportFragmentManager,id,postId)
-                    }
-                }
-            }
-        }
+        NotificationRouter.navigate(context, supportFragmentManager, args)
     }
 
-    fun presentWelcomeAction(context: Context, stage:String? = ""){
-        if(!stage.isNullOrEmpty()){
-            if(stage.equals("h1")){
-                val intent = Intent(context, WelcomeOneActivity::class.java)
-                context.startActivity(intent)
-            }
-            if(stage.equals("j2")){
-                val intent = Intent(context, WelcomeTwoActivity::class.java)
-                context.startActivity(intent)
-            }
-            if(stage.equals("j5")){
-                val intent = Intent(context, WelcomeThreeActivity::class.java)
-                context.startActivity(intent)
-            }
-            if(stage.equals("j8")){
-                val intent = Intent(context, WelcomeFourActivity::class.java)
-                context.startActivity(intent)
-            }
-            if(stage.equals("j11")){
-                val intent = Intent(context, WelcomeFiveActivity::class.java)
-                context.startActivity(intent)
-            }
-            if (stage == "birthday") {
-                if (context is MainActivity) {
-                    (context as MainActivity).goHome()
-                    context.startActivity(Intent(context, BirthdayActivity::class.java))
-                } else {
-                    val intent = Intent(context, MainActivity::class.java)
-                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-                    intent.putExtra("goBirthday", true)
-                    context.startActivity(intent)
-                }
-                return
-            }
-        }
-
+    fun presentWelcomeAction(context: Context, stage: String? = "") {
+        val args = NotificationRouter.NotificationArguments(
+            stage = stage
+        )
+        // Pass null fragmentManager, assuming no fragment-based navigation for welcome actions
+        NotificationRouter.navigate(context, null, args)
     }
 
+    fun setPlaceHolder(instance: String?): Int {
+        if (instance == null) return R.drawable.ic_new_placeholder_notif
 
-    fun setPlaceHolder(instance:String?):Int {
-        if (instance == null ) return R.drawable.ic_new_placeholder_notif
-
-        when(getInstanceTypeFromName(instance)) {
+        when (getInstanceTypeFromName(instance)) {
             InstanceType.POIS -> return R.drawable.ic_new_placeholder_notif
             InstanceType.USERS -> return R.drawable.placeholder_user
             InstanceType.NEIGHBORHOODS -> return R.drawable.placeholder_user
@@ -199,132 +67,13 @@ object NotificationActionManager {
             InstanceType.SOLICITATIONS -> return R.drawable.ic_new_placeholder_notif
             InstanceType.CONVERSATIONS -> return R.drawable.placeholder_user
             InstanceType.PARTNERS -> return R.drawable.ic_new_placeholder_notif
-            InstanceType.NONE -> R.drawable.ic_new_placeholder_notif
+            InstanceType.NONE -> return R.drawable.ic_new_placeholder_notif
             InstanceType.NEIGHBORHOODS_POSTS -> return R.drawable.placeholder_user
             InstanceType.OUTING_POSTS -> return R.drawable.placeholder_user
             InstanceType.SMALLTALK -> return R.drawable.placeholder_user
             InstanceType.AlMOSTMATCH -> return R.drawable.placeholder_user
         }
         return R.drawable.ic_new_placeholder_notif
-    }
-            /*InstanceType.NEIGHBORHOODS_POST -> showEventPost(context,supportFragmentManager, postId)
-            InstanceType.OUTINGS_POST -> showGroupPost(context,supportFragmentManager, postId)*/
-
-    private fun showContribution(context:Context,supportFragmentManager: FragmentManager, id: Int) {
-        context.startActivity(
-            Intent(context, ActionDetailActivity::class.java)
-                .putExtra(Const.ACTION_ID, id)
-                .putExtra(Const.IS_ACTION_DEMAND,false)
-        )
-    }
-    private fun showSolicitation(context:Context,supportFragmentManager: FragmentManager, id: Int) {
-        context.startActivity(
-            Intent(context, ActionDetailActivity::class.java)
-                .putExtra(Const.ACTION_ID, id)
-                .putExtra(Const.IS_ACTION_DEMAND,true)
-        )
-    }
-    private fun showConversation(context:Context,supportFragmentManager: FragmentManager, id: Int) {
-        DetailConversationActivity.isSmallTalkMode = false
-        context.startActivity(
-            Intent(context, DetailConversationActivity::class.java)
-                .putExtras(
-                    bundleOf(
-                        Const.ID to id,
-                        Const.SHOULD_OPEN_KEYBOARD to false,
-                        Const.IS_CONVERSATION_1TO1 to true,
-                        Const.IS_MEMBER to true,
-                        Const.IS_CONVERSATION to true
-                    )
-                )
-        )
-    }
-    private fun showSmallTalk(context:Context,supportFragmentManager: FragmentManager, id: Int) {
-        DetailConversationActivity.isSmallTalkMode = true
-        DetailConversationActivity.smallTalkId = id.toString()
-        context.startActivity(
-            Intent(context, DetailConversationActivity::class.java)
-                .putExtras(
-                    bundleOf(
-                        Const.ID to id,
-                        Const.SHOULD_OPEN_KEYBOARD to false,
-                        Const.IS_CONVERSATION_1TO1 to true,
-                        Const.IS_MEMBER to true,
-                        Const.IS_CONVERSATION to true
-                    )
-                )
-        )
-    }
-    private fun showAlmostMatch(context:Context,supportFragmentManager: FragmentManager, id: Int) {
-        context.startActivity(
-            Intent(context, SmallTalkListOtherBands::class.java)
-        )
-    }
-
-    private fun showUser(context:Context,supportFragmentManager: FragmentManager, id: Int) {
-        val params = HomeActionParams()
-        params.id = id
-        Navigation.navigate(context,supportFragmentManager,
-            HomeType.USER,
-            ActionSummary.SHOW, params)
-    }
-
-    private fun showPartner(context:Context, id: Int) {
-        context.startActivity(
-            Intent(context, PartnerDetailActivity::class.java)
-                .putExtra(Const.PARTNER_ID, id)
-                .putExtra(Const.IS_FROM_NOTIF,true)
-        )
-    }
-
-    private fun showPoi(fragmentManager: FragmentManager, id: Int) {
-        val poi = Poi()
-        poi.uuid = "$id"
-        ReadPoiFragment.newInstance(poi, "")
-            .show(fragmentManager, ReadPoiFragment.TAG)
-    }
-
-    private fun showOuting(context:Context,supportFragmentManager: FragmentManager, id: Int) {
-        val params = HomeActionParams()
-        params.id = id
-        Navigation.navigate(context,supportFragmentManager,
-            HomeType.OUTING,
-            ActionSummary.SHOW, params)
-    }
-
-    private fun showNeighborhood(context:Context,supportFragmentManager: FragmentManager, id: Int) {
-        val params = HomeActionParams()
-        params.id = id
-        Navigation.navigate(context,supportFragmentManager,
-            HomeType.NEIGHBORHOOD,
-            ActionSummary.SHOW, params)
-    }
-
-    private fun showResource(context:Context,supportFragmentManager: FragmentManager, id: Int) {
-        val params = HomeActionParams()
-        params.id = id
-        Navigation.navigate(context,supportFragmentManager,
-            HomeType.RESOURCE,
-            ActionSummary.SHOW, params)
-    }
-
-    private fun showEventPost(context:Context,supportFragmentManager: FragmentManager, instanceId: Int , postID:Int) {
-        val params = HomeActionParams()
-        params.id = instanceId
-        params.postId = postID
-        Navigation.navigate(context,supportFragmentManager,
-            HomeType.OUTING_POST,
-            ActionSummary.SHOW, params)
-    }
-
-    private fun showGroupPost(context:Context,supportFragmentManager: FragmentManager, instanceId: Int , postID:Int) {
-
-        val params = HomeActionParams()
-        params.id = instanceId
-        params.postId = postID
-        Navigation.navigate(context,supportFragmentManager,
-            HomeType.NEIGHBORHOOD_POST,
-            ActionSummary.SHOW, params)
     }
 
     enum class InstanceType {
@@ -345,9 +94,9 @@ object NotificationActionManager {
         NONE
     }
 
-    fun getInstanceTypeFromName(instanceName:String) : InstanceType {
+    fun getInstanceTypeFromName(instanceName: String): InstanceType {
         return when (instanceName) {
-            "pois","poi" -> InstanceType.POIS
+            "pois", "poi" -> InstanceType.POIS
             "users", "user" -> InstanceType.USERS
             "neighborhoods", "neighborhood" -> InstanceType.NEIGHBORHOODS
             "neighborhood_post" -> InstanceType.NEIGHBORHOODS_POSTS

--- a/app/src/main/java/social/entourage/android/notifications/NotificationRouter.kt
+++ b/app/src/main/java/social/entourage/android/notifications/NotificationRouter.kt
@@ -1,0 +1,295 @@
+package social.entourage.android.notifications
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import androidx.core.os.bundleOf
+import androidx.fragment.app.FragmentManager
+import com.google.gson.Gson
+import social.entourage.android.MainActivity
+import social.entourage.android.Navigation
+import social.entourage.android.R
+import social.entourage.android.actions.detail.ActionDetailActivity
+import social.entourage.android.api.model.ActionSummary
+import social.entourage.android.api.model.HomeActionParams
+import social.entourage.android.api.model.HomeType
+import social.entourage.android.api.model.guide.Poi
+import social.entourage.android.discussions.DetailConversationActivity
+import social.entourage.android.guide.poi.ReadPoiFragment
+import social.entourage.android.home.BirthdayActivity
+import social.entourage.android.small_talks.SmallTalkListOtherBands
+import social.entourage.android.tools.utils.Const
+import social.entourage.android.user.partner.PartnerDetailActivity
+import social.entourage.android.welcome.WelcomeFiveActivity
+import social.entourage.android.welcome.WelcomeFourActivity
+import social.entourage.android.welcome.WelcomeOneActivity
+import social.entourage.android.welcome.WelcomeThreeActivity
+import social.entourage.android.welcome.WelcomeTwoActivity
+import timber.log.Timber
+import social.entourage.android.tools.log.AnalyticsEvents
+
+/**
+ * Centralized Router for all Notification-related navigation.
+ * Handles both Push Notifications (via MainActivity) and In-App Notifications.
+ */
+object NotificationRouter {
+
+    const val TAG = "NotificationRouter"
+
+    // Argument wrapper to unify Push and In-App data
+    data class NotificationArguments(
+        val instance: String? = null,
+        val id: Int = 0,
+        val postId: Int? = null,
+        val stage: String? = null,
+        val popup: String? = null,
+        val notifContext: String? = null,
+        val tracking: String? = null,
+        val contentJson: String? = null // For passing raw content if needed
+    )
+
+    private val validTracking = listOf(
+        "public_chat_message_on_create",
+        "post_on_create_to_outing",
+        "post_on_create",
+        "comment_on_create_to_outing",
+        "comment_on_create",
+        "chat_message_on_mention",
+        "reaction_on_create",
+        "survey_response_on_create"
+    )
+
+    fun navigate(context: Context, fragmentManager: FragmentManager?, args: NotificationArguments) {
+        Timber.tag(TAG).d("Navigate with args: $args")
+        logNotificationClicked(context, args)
+
+        // 1. Handle Popup / Special Contexts
+        if (args.popup == "outing_on_day_before" || args.notifContext == "outing_on_day_before") {
+            if (context is MainActivity) {
+                context.ifEventLastDay(args.id)
+            } else {
+                MainActivity.shouldLaunchEventPopUp = args.id
+                if (context is Activity) {
+                    context.finish()
+                }
+            }
+            return
+        }
+
+        // 2. Handle Stages (Welcome / Birthday)
+        if (!args.stage.isNullOrEmpty()) {
+            when (args.stage) {
+                "h1" -> context.startActivity(Intent(context, WelcomeOneActivity::class.java))
+                "j2" -> context.startActivity(Intent(context, WelcomeTwoActivity::class.java))
+                "j5" -> context.startActivity(Intent(context, WelcomeThreeActivity::class.java))
+                "j8" -> context.startActivity(Intent(context, WelcomeFourActivity::class.java))
+                "j11" -> context.startActivity(Intent(context, WelcomeFiveActivity::class.java))
+                "birthday" -> {
+                    val intent = Intent(context, BirthdayActivity::class.java)
+                    intent.putExtra("notification_content", args.contentJson)
+
+                    if (context !is MainActivity) {
+                        // If not in MainActivity, route through it to ensure back stack
+                        val mainIntent = Intent(context, MainActivity::class.java)
+                        mainIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+                        mainIntent.putExtra("goBirthday", true)
+                        // Pass content along if needed by MainActivity logic, though goBirthday usually handles it
+                        args.contentJson?.let { mainIntent.putExtra("notification_content", it) }
+                        context.startActivity(mainIntent)
+                    } else {
+                        (context as MainActivity).goHome()
+                        context.startActivity(intent)
+                    }
+                    return
+                }
+            }
+        }
+
+        // 3. Handle Discussion / Outing redirection (The "Complex Logic")
+        val isDiscussionTracking = (args.notifContext in validTracking || args.tracking in validTracking)
+        if ((args.instance == "outings" || args.instance == "outing") && isDiscussionTracking) {
+            DetailConversationActivity.isSmallTalkMode = false
+            val intent = Intent(context, DetailConversationActivity::class.java).apply {
+                putExtras(
+                    bundleOf(
+                        Const.ID to args.id,
+                        Const.SHOULD_OPEN_KEYBOARD to false,
+                        Const.IS_CONVERSATION_1TO1 to true,
+                        Const.IS_MEMBER to true,
+                        Const.IS_CONVERSATION to true,
+                        Const.HAS_TO_SHOW_MESSAGE to true
+                    )
+                )
+            }
+            context.startActivity(intent)
+            return
+        }
+
+        // 4. Handle Standard Instances
+        val instanceType = getInstanceTypeFromName(args.instance)
+        when (instanceType) {
+            InstanceType.POIS -> {
+                val poi = Poi()
+                poi.uuid = "${args.id}"
+                ReadPoiFragment.newInstance(poi, "")
+                    .show(fragmentManager!!, ReadPoiFragment.TAG)
+            }
+            InstanceType.USERS -> {
+                val params = HomeActionParams()
+                params.id = args.id
+                Navigation.navigate(context, fragmentManager!!, HomeType.USER, ActionSummary.SHOW, params)
+            }
+            InstanceType.NEIGHBORHOODS -> {
+                val params = HomeActionParams()
+                params.id = args.id
+                Navigation.navigate(context, fragmentManager!!, HomeType.NEIGHBORHOOD, ActionSummary.SHOW, params)
+            }
+            InstanceType.RESOURCES -> {
+                val params = HomeActionParams()
+                params.id = args.id
+                Navigation.navigate(context, fragmentManager!!, HomeType.RESOURCE, ActionSummary.SHOW, params)
+            }
+            InstanceType.OUTINGS -> {
+                val params = HomeActionParams()
+                params.id = args.id
+                Navigation.navigate(context, fragmentManager!!, HomeType.OUTING, ActionSummary.SHOW, params)
+            }
+            InstanceType.OUTINGS_MESSAGE, InstanceType.CONVERSATIONS -> {
+                DetailConversationActivity.isSmallTalkMode = false
+                context.startActivity(
+                    Intent(context, DetailConversationActivity::class.java).putExtras(
+                        bundleOf(
+                            Const.ID to args.id,
+                            Const.SHOULD_OPEN_KEYBOARD to false,
+                            Const.IS_CONVERSATION_1TO1 to true,
+                            Const.IS_MEMBER to true,
+                            Const.IS_CONVERSATION to true
+                        )
+                    )
+                )
+            }
+            InstanceType.CONTRIBUTIONS -> {
+                context.startActivity(
+                    Intent(context, ActionDetailActivity::class.java)
+                        .putExtra(Const.ACTION_ID, args.id)
+                        .putExtra(Const.IS_ACTION_DEMAND, false)
+                )
+            }
+            InstanceType.SOLICITATIONS -> {
+                context.startActivity(
+                    Intent(context, ActionDetailActivity::class.java)
+                        .putExtra(Const.ACTION_ID, args.id)
+                        .putExtra(Const.IS_ACTION_DEMAND, true)
+                )
+            }
+            InstanceType.SMALLTALK -> {
+                DetailConversationActivity.isSmallTalkMode = true
+                DetailConversationActivity.smallTalkId = args.id.toString()
+                context.startActivity(
+                    Intent(context, DetailConversationActivity::class.java).putExtras(
+                        bundleOf(
+                            Const.ID to args.id,
+                            Const.SHOULD_OPEN_KEYBOARD to false,
+                            Const.IS_CONVERSATION_1TO1 to true,
+                            Const.IS_MEMBER to true,
+                            Const.IS_CONVERSATION to true
+                        )
+                    )
+                )
+            }
+            InstanceType.AlMOSTMATCH -> {
+                context.startActivity(Intent(context, SmallTalkListOtherBands::class.java))
+            }
+            InstanceType.PARTNERS -> {
+                context.startActivity(
+                    Intent(context, PartnerDetailActivity::class.java)
+                        .putExtra(Const.PARTNER_ID, args.id)
+                        .putExtra(Const.IS_FROM_NOTIF, true)
+                )
+            }
+            InstanceType.NONE -> {
+                // Fallback or explicit NONE handling
+                return
+            }
+            else -> {
+                // Handle Post types which are not directly in the enum or need special handling
+                if (instanceType == InstanceType.OUTING_POSTS) {
+                     args.postId?.let { postId ->
+                        val params = HomeActionParams()
+                        params.id = args.id
+                        params.postId = postId
+                        Navigation.navigate(context, fragmentManager!!, HomeType.OUTING_POST, ActionSummary.SHOW, params)
+                    }
+                } else if (instanceType == InstanceType.NEIGHBORHOODS_POSTS) {
+                    args.postId?.let { postId ->
+                        val params = HomeActionParams()
+                        params.id = args.id
+                        params.postId = postId
+                        Navigation.navigate(context, fragmentManager!!, HomeType.NEIGHBORHOOD_POST, ActionSummary.SHOW, params)
+                    }
+                }
+            }
+        }
+    }
+
+    enum class InstanceType {
+        POIS, USERS, NEIGHBORHOODS, NEIGHBORHOODS_POSTS, RESOURCES, OUTINGS,
+        OUTINGS_MESSAGE, OUTING_POSTS, CONTRIBUTIONS, SOLICITATIONS,
+        CONVERSATIONS, SMALLTALK, AlMOSTMATCH, PARTNERS, NONE
+    }
+
+    private fun logNotificationClicked(context: Context, args: NotificationArguments) {
+        val stage = args.stage
+        if (!stage.isNullOrEmpty()) {
+            when (stage) {
+                "h1" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay1)
+                "j2" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay2)
+                "j5" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay5)
+                "j!" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay8)
+                "j11" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay11)
+            }
+        }
+        val tracking = args.tracking
+        if (!tracking.isNullOrEmpty()) {
+             when (tracking) {
+                "join_request_on_create" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__MemberEvent)
+                "outing_on_update" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__ModifiedEvent)
+                "outing_on_create" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__PostEvent)
+                "post_on_create_to_neighborhood" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__PostGroup)
+                "comment_on_create_to_neighborhood" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__CommentGroup)
+                "comment_on_create_to_outing" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__CommentEvent)
+                "outing_on_add_to_neighborhood" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__EventInGroup)
+                "contribution_on_create" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__Contribution)
+                "solicitation_on_create" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__Demand)
+                "private_chat_message_on_create" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__PrivateMessage)
+                "join_request_on_create_to_neighborhood" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__MemberGroup)
+                "join_request_on_create_to_outing" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__MemberEvent)
+                "outing_on_cancel" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__CanceledEvent)
+                "post_on_create_to_outing" -> AnalyticsEvents.logEvent(AnalyticsEvents.NotificationReceived__PostEvent)
+                "public_chat_message_on_create" -> AnalyticsEvents.logEvent("UNDEFINED_PUSH_TRACKING")
+             }
+        }
+    }
+
+    private fun getInstanceTypeFromName(instanceName: String?): InstanceType {
+        return when (instanceName) {
+            "pois", "poi" -> InstanceType.POIS
+            "users", "user" -> InstanceType.USERS
+            "neighborhoods", "neighborhood" -> InstanceType.NEIGHBORHOODS
+            "neighborhood_post" -> InstanceType.NEIGHBORHOODS_POSTS
+            "resources", "resource" -> InstanceType.RESOURCES
+            "outings", "outing" -> InstanceType.OUTINGS
+            "outings_message" -> InstanceType.OUTINGS_MESSAGE
+            "outing_post" -> InstanceType.OUTING_POSTS
+            "contributions", "contribution" -> InstanceType.CONTRIBUTIONS
+            "solicitations", "solicitation" -> InstanceType.SOLICITATIONS
+            "conversations", "conversation" -> InstanceType.CONVERSATIONS
+            "smalltalk", "user_smalltalk " -> InstanceType.SMALLTALK
+            "almost_matches" -> InstanceType.AlMOSTMATCH
+            "partners" -> InstanceType.PARTNERS
+            else -> InstanceType.NONE
+        }
+    }
+}

--- a/app/src/main/java/social/entourage/android/notifications/PushNotificationManager.kt
+++ b/app/src/main/java/social/entourage/android/notifications/PushNotificationManager.kt
@@ -11,19 +11,18 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.preference.PreferenceManager
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.edit
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.os.bundleOf
-import androidx.preference.PreferenceManager
 import com.google.firebase.messaging.RemoteMessage
 import com.google.gson.Gson
 import social.entourage.android.EntourageApplication
 import social.entourage.android.MainActivity
 import social.entourage.android.R
 import social.entourage.android.api.model.TimestampedObject
-import social.entourage.android.api.model.feed.FeedItem
 import social.entourage.android.api.model.notification.PushNotificationContent
 import social.entourage.android.api.model.notification.PushNotificationMessage
 import social.entourage.android.discussions.DetailConversationActivity
@@ -35,30 +34,32 @@ import social.entourage.android.welcome.WelcomeOneActivity
 import social.entourage.android.welcome.WelcomeThreeActivity
 import social.entourage.android.welcome.WelcomeTwoActivity
 import timber.log.Timber
+import java.util.*
 
 /**
- * Singleton that handles the push notifications
- * Created by Mihai Ionescu on 24/10/2017.
+ * Singleton that handles push notifications
  */
 object PushNotificationManager {
     // ----------------------------------
     // CONSTANTS
     // ----------------------------------
     const val PUSH_MESSAGE = "social.entourage.android.PUSH_MESSAGE"
-
-    private const val MIN_NOTIFICATION_ID = 40
-    private const val PREFERENCE_LAST_NOTIFICATION_ID = "PREFERENCE_LAST_NOTIFICATION_ID"
-    private const val KEY_SENDER = "sender"
-    private const val KEY_OBJECT = "object"
+    const val KEY_SENDER = "sender"
+    const val KEY_OBJECT = "object"
     const val KEY_CONTENT = "content"
+    const val PREFERENCE_LAST_NOTIFICATION_ID = "PREFERENCE_LAST_NOTIFICATION_ID"
+    private const val MIN_NOTIFICATION_ID = 10000
+
+    const val ACTION_OPEN_NOTIFICATION = "social.entourage.android.ACTION_OPEN_NOTIFICATION"
 
     // ----------------------------------
     // ATTRIBUTES
     // ----------------------------------
-    private var pushNotifications = HashMap<String, MutableList<PushNotificationMessage>>()
-    // ------------------------------------
+    private var pushNotifications: MutableMap<String, MutableList<PushNotificationMessage>> = HashMap()
+
+    // ----------------------------------
     // INTERNAL PUSH NOTIFICATIONS HANDLING
-    // ------------------------------------
+    // ----------------------------------
     /**
      * Handle a push notification received from the server
      * @param pushNotificationMessage The pushNotificationMessage that we use to build the push notification
@@ -84,48 +85,6 @@ object PushNotificationManager {
         messageList.add(pushNotificationMessage)
         pushNotifications[pushNotificationMessage.hash] = messageList
     }
-    /**
-     * Removes the notifications for a feed item, updating the groups if necessary
-     * @param feedItem the feed item from which to remove the notifications
-     * @return the number of push notifications that were removed
-     */
-    /*@Synchronized
-    fun removePushNotificationsForFeedItem(feedItem: FeedItem): Int {
-        val feedItemId = feedItem.id
-        val feedType = feedItem.type
-        var nbNotifsFound = 0
-        val newPushNotifications =  HashMap<String, MutableList<PushNotificationMessage>>()
-        for(key in pushNotifications.keys) {
-            pushNotifications[key]?.let { messageList->
-                var messageListChanged = false
-                val newPushNotificationMessageList = ArrayList<PushNotificationMessage>()
-                for(message in messageList) {
-                    val content = message.content
-                    if (content != null && content.joinableId == feedItemId) {
-                        if((TimestampedObject.ENTOURAGE_CARD == feedType && content.isEntourageRelated)){
-                            nbNotifsFound++
-                            messageListChanged = true
-                            if (PushNotificationContent.TYPE_NEW_JOIN_REQUEST == content.type) {
-                                // Don't delete the join requests push, just hide them
-                                message.isVisible = false
-                            } else {
-                                continue
-                            }
-                        }
-                    }
-                    newPushNotificationMessageList.add(message)
-                }
-                if (!messageListChanged
-                        || updateNotificationGroup(key, newPushNotificationMessageList)
-                        ||newPushNotificationMessageList.isNotEmpty()) {
-                    // list not empty we keep it
-                    newPushNotifications[key] = newPushNotificationMessageList
-                }
-            }
-        }
-        pushNotifications = newPushNotifications
-        return nbNotifsFound
-    }*/
 
     /**
      * Removes a notification from our internal list
@@ -152,18 +111,6 @@ object PushNotificationManager {
         pushNotifications = newPushNotifications
         return nbMsgFound
     }
-
-    /**
-     * Removes notifications from a feed that matches the required type (see [PushNotificationContent])
-     * @param feedItem the feed item
-     * @param userId not used
-     * @param pushType the required type
-     * @return the number of push notifications that were removed
-     */
-    /*@Synchronized
-    fun removePushNotification(feedItem: FeedItem, userId: Int, pushType: String): Int {
-        return removePushNotification(feedItem.id, feedItem.type, userId, pushType)
-    }*/
 
     /**
      * Removes notifications from a feed that matches the required type (see [PushNotificationContent])
@@ -201,7 +148,8 @@ object PushNotificationManager {
                 }
                 if (!messageListChanged
                         || updateNotificationGroup(key, newPushNotificationMessageList)
-                        ||newPushNotificationMessageList.isNotEmpty()) {
+                        || newPushNotificationMessageList.isNotEmpty()) {
+                    // list not empty we keep it
                     newPushNotifications[key] = newPushNotificationMessageList
                 }
             }
@@ -211,21 +159,56 @@ object PushNotificationManager {
     }
 
     /**
-     * Removes all the notifications, both from OS and our internal list
+     * Removes all the notifications
+     * @return the number of push notifications that were removed
      */
     @Synchronized
-    fun removeAllPushNotifications() {
-        // cancel all the notifications
+    fun removeAllPushNotifications(): Int {
+        var count = 0
         for (messageList in pushNotifications.values) {
-            if (messageList.isEmpty()) continue
-            NotificationManagerCompat.from(EntourageApplication.get()).cancel(messageList[0].pushNotificationTag,  messageList[0].pushNotificationId)
+            count += messageList.size
         }
-        // remove all the notifications from our internal list
         pushNotifications.clear()
         NotificationManagerCompat.from(EntourageApplication.get()).cancelAll()
+        return count
     }
+
+    /**
+     * Updates a group of notifications.
+     * Use this if the messages that are grouped need to be updated, for example, for the summmary
+     * @param key the key of the group
+     * @param pushNotificationMessageList the list of messages in the group
+     * @return true if the group was updated
+     */
+    private fun updateNotificationGroup(key: String, pushNotificationMessageList: List<PushNotificationMessage>): Boolean {
+        // Validation
+        if (pushNotificationMessageList.isEmpty()) {
+            return false
+        }
+        val count = pushNotificationMessageList.size
+        // get the last message
+        val lastMessage = pushNotificationMessageList[count - 1]
+        // retrieve the context
+        val context = EntourageApplication.get()
+        // update the notification
+        val channelId = context.getString(R.string.app_name)
+        val builder = NotificationCompat.Builder(context, channelId)
+                .setSmallIcon(R.drawable.ic_entourage_logo_one_color)
+                .setStyle(NotificationCompat.BigTextStyle())
+                .setContentIntent(createMessagePendingIntent(lastMessage, context))
+                .setLargeIcon(BitmapFactory.decodeResource(context.resources, R.drawable.ic_entourage_logo_two_colors))
+                .setContentTitle(lastMessage.getContentTitleForCount(count, context))
+                .setContentText(lastMessage.getContentTextForCount(count, context))
+                .setColor(ResourcesCompat.getColor(context.resources,R.color.accent,null))
+        val notification = builder.build()
+        notification.defaults = NotificationCompat.DEFAULT_LIGHTS
+        notification.flags = NotificationCompat.FLAG_AUTO_CANCEL or NotificationCompat.FLAG_SHOW_LIGHTS
+        NotificationManagerCompat.from(context).notify(lastMessage.pushNotificationTag, lastMessage.pushNotificationId, notification)
+        return true
+    }
+
     // ----------------------------------
-    // PUSH NOTIFICATION UI HANDLING
+    // PRIVATE METHODS
     // ----------------------------------
     /**
      * Creates and displays a OS notification, using tag and id
@@ -278,33 +261,29 @@ object PushNotificationManager {
         }
 
 
-
+        // CLICKED Intent
         val clickedIntent = Intent(context, NotificationActionReceiver::class.java).apply {
             action = NotificationActionReceiver.ACTION_CLICKED
             putExtra("notification_content", Gson().toJson(pushNotificationMessage))
         }
 
-
+        // DISMISSED Intent
         val dismissedIntent = Intent(context, NotificationActionReceiver::class.java).apply {
             action = NotificationActionReceiver.ACTION_DISMISSED
-            putExtra("notification_content", Gson().toJson(pushNotificationMessage)) // ou n'importe quelle autre information que vous voulez passer
+            putExtra("notification_content", Gson().toJson(pushNotificationMessage))
         }
 
         val requestCode = pushNotificationMessage.pushNotificationId
-        val clickedPendingIntent = PendingIntent.getBroadcast(
-            context, requestCode, clickedIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
 
+        // Note: dismissedPendingIntent is used, but clickedPendingIntent is NOT used in setContentIntent below.
+        // Instead, createMessagePendingIntent is used.
         val dismissedPendingIntent = PendingIntent.getBroadcast(
             context, requestCode, dismissedIntent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
 
         val channelId = context.getString(R.string.app_name)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-
             val notificationChannel = NotificationChannel(channelId, channelId, NotificationManager.IMPORTANCE_DEFAULT)
-
-            // Configure the notification channel.
             notificationChannel.description = channelId
             notificationChannel.enableLights(true)
             notificationChannel.lightColor = Color.RED
@@ -318,7 +297,7 @@ object PushNotificationManager {
                 .setContentTitle(pushNotificationMessage.getContentTitleForCount(count, context))
                 .setContentText(pushNotificationMessage.getContentTextForCount(count, context))
                 .setColor(ResourcesCompat.getColor(context.resources,R.color.accent,null))
-                .setDeleteIntent(dismissedPendingIntent) // Ajoutez le PendingIntent pour l'action de suppression
+                .setDeleteIntent(dismissedPendingIntent)
 
         val notification = builder.build()
         notification.defaults = NotificationCompat.DEFAULT_LIGHTS
@@ -332,8 +311,6 @@ object PushNotificationManager {
         val channelId = context.getString(R.string.app_name)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val notificationChannel = NotificationChannel(channelId, channelId, NotificationManager.IMPORTANCE_DEFAULT)
-
-            // Configure the notification channel.
             notificationChannel.description = channelId
             notificationChannel.enableLights(true)
             notificationChannel.lightColor = Color.RED
@@ -351,146 +328,31 @@ object PushNotificationManager {
         val notification = builder.build()
         notification.defaults = NotificationCompat.DEFAULT_LIGHTS
         notification.flags = NotificationCompat.FLAG_AUTO_CANCEL or NotificationCompat.FLAG_SHOW_LIGHTS
-        NotificationManagerCompat.from(context).notify(PushNotificationMessage.Companion.PushNotificationIds.FCM, notification)
+        NotificationManagerCompat.from(context).notify("FCM", 0, notification)
     }
-
-    /**
-     * Updates a group of notifications. If the group is empty, it removes the notification
-     * @param key the key of the group
-     * @param pushNotificationMessageList the message list
-     * @return true if the group was updated, false if it was removed
-     */
-    private fun updateNotificationGroup(key: String, pushNotificationMessageList: List<PushNotificationMessage>): Boolean {
-        // get the visible messages count
-        var isGroupEmpty = true
-        for (message in pushNotificationMessageList) {
-            if (message.isVisible) {
-                isGroupEmpty = false
-                break
-            }
-        }
-        if (isGroupEmpty) {
-            // no more messages, cancel the notification
-            var notificationTag: String? = null
-            val notificationId: Int
-            val separator = key.indexOf(PushNotificationMessage.HASH_SEPARATOR)
-            if (separator > 0) {
-                notificationTag = key.substring(0, separator)
-                notificationId = key.substring(separator + 1).toInt()
-            } else {
-                notificationId = key.toInt()
-            }
-            NotificationManagerCompat.from(EntourageApplication.get()).cancel(notificationTag, notificationId)
-            return false
-        } else {
-            displayPushNotification(pushNotificationMessageList.last(), EntourageApplication.get())
-        }
-        return true
-    }
-
-
 
     /**
      * Creates the pending intent to be used when creating the OS notification
+     * REFACTORED: Now always returns an Intent to MainActivity with ACTION_OPEN_NOTIFICATION.
      * @param pushNotificationMessage the pushNotificationMessage
      * @param context the content
      * @return the [PendingIntent]
      */
     private fun createMessagePendingIntent(pushNotificationMessage: PushNotificationMessage, context: Context): PendingIntent {
-        val args = Bundle()
-        args.putSerializable(PUSH_MESSAGE, pushNotificationMessage)
-        val messageType: String = pushNotificationMessage.content?.type ?:""
+        val intent = Intent(context, MainActivity::class.java)
+        intent.action = ACTION_OPEN_NOTIFICATION
 
-        if(pushNotificationMessage.content?.extra?.stage == "h1"){
-            val intent = Intent(context, WelcomeOneActivity::class.java)
-            intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
-            return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
-        }
-        if(pushNotificationMessage.content?.extra?.stage == "j2"){
-            val intent = Intent(context, WelcomeTwoActivity::class.java)
-            intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
-            intent.putExtra("notification_content_boolean", true)
-            return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
-        }
-        if(pushNotificationMessage.content?.extra?.stage == "j5"){
-            val intent = Intent(context, WelcomeThreeActivity::class.java)
-            intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
-            return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
-        }
-        if(pushNotificationMessage.content?.extra?.stage == "j8"){
-            val intent = Intent(context, WelcomeFourActivity::class.java)
-            intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
-            return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
-        }
-        if(pushNotificationMessage.content?.extra?.stage == "j11"){
-            val intent = Intent(context, WelcomeFiveActivity::class.java)
-            intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
-            return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
-        }
-        if(pushNotificationMessage.content?.extra?.stage == "birthday"){
-            val intent = Intent(context, MainActivity::class.java)
-            intent.putExtra("goBirthday", true)
-            intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
-            return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
-        }
+        // Pass the raw content as JSON
+        intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
 
-        val instance = pushNotificationMessage.content?.extra?.instance
-        val tracking = pushNotificationMessage.content?.extra?.tracking
-
-        val isDiscussionTracking = tracking in listOf(
-            "public_chat_message_on_create",
-            "post_on_create_to_outing",
-            "post_on_create",
-            "comment_on_create_to_outing",
-            "comment_on_create",
-            "chat_message_on_mention",
-            "reaction_on_create",
-            "survey_response_on_create"
+        return PendingIntent.getActivity(
+            context,
+            pushNotificationMessage.pushNotificationId,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
-        if ((instance == "outings" || instance == "outing") && isDiscussionTracking) {
-            DetailConversationActivity.isSmallTalkMode = false
-            val intent = Intent(context, DetailConversationActivity::class.java).apply {
-                putExtras(
-                    bundleOf(
-                        Const.ID to pushNotificationMessage.content?.joinableId?.toInt(), // ou .toLong() selon ton implémentation
-                        Const.SHOULD_OPEN_KEYBOARD to false,
-                        Const.IS_CONVERSATION_1TO1 to true, // à adapter selon besoin
-                        Const.IS_MEMBER to true,
-                        Const.IS_CONVERSATION to true,
-                        Const.HAS_TO_SHOW_MESSAGE to true, // à adapter selon besoin
-                        "notification_content" to Gson().toJson(pushNotificationMessage.content)
-                    )
-                )
-            }
-
-            return PendingIntent.getActivity(
-                context,
-                pushNotificationMessage.pushNotificationId,
-                intent,
-                PendingIntent.FLAG_IMMUTABLE
-            )
-        }
-
-        val messageIntent = Intent(context, MainActivity::class.java)
-        when (messageType) {
-            PushNotificationContent.TYPE_NEW_JOIN_REQUEST ->                 // because of the grouping, we need an intent that is specific for each entourage
-                messageIntent.data = Uri.parse("entourage-notif://" + pushNotificationMessage.pushNotificationTag)
-            PushNotificationContent.TYPE_NEW_CHAT_MESSAGE,
-            PushNotificationContent.TYPE_JOIN_REQUEST_ACCEPTED,
-            PushNotificationContent.TYPE_ENTOURAGE_INVITATION,
-            PushNotificationContent.TYPE_INVITATION_STATUS -> {
-            }
-            else -> Timber.i("Notif has no pending intent")
-        }
-        messageIntent.action = messageType
-        messageIntent.putExtras(args)
-        messageIntent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
-        return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, messageIntent, PendingIntent.FLAG_IMMUTABLE)
     }
 
-    // ----------------------------------
-    // STATIC METHODS
-    // ----------------------------------
     /**
      * Creates a [PushNotificationMessage] from the remoteMessage received from the firebase messaging server
      * @param remoteMessage remoteMessage from FirebaseMessaging
@@ -521,37 +383,5 @@ object PushNotificationManager {
         }
         sharedPreferences.edit { putInt(PREFERENCE_LAST_NOTIFICATION_ID, id) }
         return id
-    }
-
-    private fun doTracking(notificationContent:String){
-        try {
-            val pushNotif = Gson().fromJson(notificationContent, PushNotificationContent::class.java)
-            val stage = pushNotif.extra?.stage
-            if(stage.equals("h1")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay1)}
-            if(stage.equals("j2")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay2)}
-            if(stage.equals("j5")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay5)}
-            if(stage.equals("j!")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay8)}
-            if(stage.equals("j11")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__OfferHelp__WDay11)}
-            val tracking = pushNotif.extra?.tracking
-            if(tracking != null) {
-                if(tracking.equals("join_request_on_create")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__MemberEvent)}
-                if(tracking.equals("outing_on_update")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__ModifiedEvent)}
-                if(tracking.equals("outing_on_create")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__PostEvent)}
-                if(tracking.equals("post_on_create_to_neighborhood")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__PostGroup)}
-                if(tracking.equals("comment_on_create_to_neighborhood")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__CommentGroup)}
-                if(tracking.equals("comment_on_create_to_outing")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__CommentEvent)}
-                if(tracking.equals("outing_on_add_to_neighborhood")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__EventInGroup)}
-                if(tracking.equals("contribution_on_create")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__Contribution)}
-                if(tracking.equals("solicitation_on_create")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__Demand)}
-                if(tracking.equals("private_chat_message_on_create")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__PrivateMessage)}
-                if(tracking.equals("join_request_on_create_to_neighborhood")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__MemberGroup)}
-                if(tracking.equals("join_request_on_create_to_outing")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__MemberEvent)}
-                if(tracking.equals("outing_on_cancel")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationClicked__CanceledEvent)}
-                if(tracking.equals("post_on_create_to_outing")){AnalyticsEvents.logEvent(AnalyticsEvents.NotificationReceived__PostEvent)}
-                if(tracking.equals("public_chat_message_on_create")){AnalyticsEvents.logEvent("UNDEFINED_PUSH_TRACKING")}
-            }
-        }catch (e:Exception){
-
-        }
     }
 }


### PR DESCRIPTION
Refactored notification navigation logic into a centralized `NotificationRouter`.

- Created `NotificationRouter` to handle both Push and In-App notification navigation.
- Simplified `PushNotificationManager` to route all notifications to `MainActivity` with `ACTION_OPEN_NOTIFICATION`.
- Updated `MainActivity` to delegate notification handling to `NotificationRouter`.
- Refactored `NotificationActionManager` to be a wrapper around `NotificationRouter`.
- Preserved analytics tracking and system notification clearing logic.

---
*PR created automatically by Jules for task [16013340140186399410](https://jules.google.com/task/16013340140186399410) started by @clemPerrousset*