### PR TITLE
Fix birthday notification routing logic

### DIFF
--- a/app/src/main/java/social/entourage/android/notifications/PushNotificationManager.kt
+++ b/app/src/main/java/social/entourage/android/notifications/PushNotificationManager.kt
@@ -429,13 +429,6 @@ object PushNotificationManager {
             return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
         }
         if(pushNotificationMessage.content?.extra?.stage == "birthday"){
-            val intent = Intent(context, BirthdayActivity::class.java) // Assure-toi d'avoir importé BirthdayActivity
-            intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-
-            return PendingIntent.getActivity(context, pushNotificationMessage.pushNotificationId, intent, PendingIntent.FLAG_IMMUTABLE)
-        }
-        if(pushNotificationMessage.content?.extra?.stage == "birthday"){
             val intent = Intent(context, MainActivity::class.java)
             intent.putExtra("goBirthday", true)
             intent.putExtra("notification_content", Gson().toJson(pushNotificationMessage.content))


### PR DESCRIPTION
Removed a duplicate `if` block in `PushNotificationManager.kt` that was preventing the correct handling of "birthday" push notifications. The removed block was intercepting the notification and trying to open `BirthdayActivity` directly, instead of letting the subsequent block route it through `MainActivity` (which handles the back stack and initialization properly via the `goBirthday` extra). This fix ensures that clicking the birthday notification correctly opens the Birthday screen.

---
*PR created automatically by Jules for task [7791003257885520806](https://jules.google.com/task/7791003257885520806) started by @clemPerrousset*