### PR TITLE
Refactor event date formatting to exclude year

### DIFF
--- a/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
+++ b/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
@@ -377,11 +377,7 @@ object Utils {
         val cal = Calendar.getInstance()
         cal.time = date
         val now = Calendar.getInstance()
-        val pattern = if (cal.get(Calendar.YEAR) == now.get(Calendar.YEAR)) {
-            "EEE d MMM"
-        } else {
-            "EEE d MMM yyyy"
-        }
+        val pattern = "EEE d MMM"
         return SimpleDateFormat(pattern, locale).format(date).replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
     }
 
@@ -390,11 +386,7 @@ object Utils {
         val cal = Calendar.getInstance()
         cal.time = date
         val now = Calendar.getInstance()
-        val pattern = if (cal.get(Calendar.YEAR) == now.get(Calendar.YEAR)) {
-            "EEEE d MMMM"
-        } else {
-            "EEEE d MMMM yyyy"
-        }
+        val pattern = "EEEE d MMMM"
         return SimpleDateFormat(pattern, locale).format(date).replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
     }
 }


### PR DESCRIPTION
This PR updates the event date formatting logic in `Utils.kt`.
Previously, the year was appended to the date if the event's year differed from the current year.
The new implementation always uses the format without the year ("EEE d MMM" for short, "EEEE d MMMM" for long), ensuring a consistent display across all event views (Home, Event List, Event Detail, Discussions) as requested in the ticket.
Verified by code inspection as local build environment is unavailable.

---
*PR created automatically by Jules for task [14018808771259934362](https://jules.google.com/task/14018808771259934362) started by @clemPerrousset*