### PR TITLE
Fix IllegalArgumentException in HomeFragment observers

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -704,13 +704,13 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
     }
 
     private fun setObservations() {
-        homePresenter.summary.observe(viewLifecycleOwner, ::updateContributionsView)
-        homePresenter.getAllEvents.observe(viewLifecycleOwner, ::handleEvent)
-        homePresenter.getAllActions.observe(viewLifecycleOwner, ::handleAction)
-        homePresenter.pedagogicalContent.observe(viewLifecycleOwner, ::handlePedago)
-        homePresenter.pedagogicalInitialContent.observe(viewLifecycleOwner, ::handleInitialPedago)
-        homePresenter.notifsCount.observe(viewLifecycleOwner, ::updateNotifsCount)
-        actionsPresenter.unreadMessages.observe(viewLifecycleOwner, ::updateUnreadCount)
+        homePresenter.summary.observe(viewLifecycleOwner) { updateContributionsView(it) }
+        homePresenter.getAllEvents.observe(viewLifecycleOwner) { handleEvent(it) }
+        homePresenter.getAllActions.observe(viewLifecycleOwner) { handleAction(it) }
+        homePresenter.pedagogicalContent.observe(viewLifecycleOwner) { handlePedago(it) }
+        homePresenter.pedagogicalInitialContent.observe(viewLifecycleOwner) { handleInitialPedago(it) }
+        homePresenter.notifsCount.observe(viewLifecycleOwner) { updateNotifsCount(it) }
+        actionsPresenter.unreadMessages.observe(viewLifecycleOwner) { updateUnreadCount(it) }
     }
 
     fun handleGroup(allGroup: MutableList<Group>?) {


### PR DESCRIPTION
The application was crashing with `java.lang.IllegalArgumentException: Cannot add the same observer with different lifecycles` in `HomeFragment`. This happens when `LiveData.observe` is called with an observer instance that is already attached to a different (likely destroyed but not yet cleaned up, or just different) lifecycle owner.

In Kotlin, method references like `::updateContributionsView` are bound to the receiver (`this`, the Fragment instance). If the Fragment instance is retained (e.g., in the backstack) and the view is destroyed and recreated, `onCreateView` is called again. The method reference created in the new `onCreateView` is equal to the one created in the previous `onCreateView` because they refer to the same method on the same object instance.

`LiveData` treats equal objects as the same observer. If the previous observer was not fully detached (or if `LiveData` strictly forbids re-attaching the same observer to a new owner), it throws the exception.

The fix is to wrap the method calls in lambdas (e.g., `{ updateContributionsView(it) }`). Each lambda expression creates a new anonymous class instance, ensuring that the observer object is unique for each call to `setObservations`. This avoids the identity collision and fixes the crash.

---
*PR created automatically by Jules for task [13306063886332630406](https://jules.google.com/task/13306063886332630406) started by @clemPerrousset*