### PR TITLE
Fix ClassCastException in Home adapters sharing RecycledViewPool

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomeEventAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeEventAdapter.kt
@@ -61,6 +61,11 @@ class HomeEventAdapter(
     override fun getItemCount(): Int {
         return events.size
     }
+
+    override fun getItemViewType(position: Int): Int {
+        return R.layout.home_v2_event_item_layout
+    }
+
     fun getEventIds(): Set<Int> {
         return events.mapNotNull { it.id }.toSet()
     }

--- a/app/src/main/java/social/entourage/android/home/HomeGroupAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeGroupAdapter.kt
@@ -42,6 +42,10 @@ class HomeGroupAdapter: RecyclerView.Adapter<HomeGroupAdapter.GroupViewHolder>()
         return groups.size
     }
 
+    override fun getItemViewType(position: Int): Int {
+        return R.layout.home_v2_group_item_layout
+    }
+
     override fun onBindViewHolder(holder: GroupViewHolder, position: Int) {
         val group = groups[position]
         holder.binding.layout.setOnClickListener {view ->

--- a/app/src/main/java/social/entourage/android/home/HomeInitialPedagoAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeInitialPedagoAdapter.kt
@@ -41,6 +41,10 @@ class HomeInitialPedagoAdapter(private var onItemClickListener: OnItemClick): Re
         return pedagos.size
     }
 
+    override fun getItemViewType(position: Int): Int {
+        return R.layout.home_v2_initial_pedago_item_layout
+    }
+
     override fun onBindViewHolder(holder: PedagoViewHolder, position: Int) {
         val pedago = pedagos[position]
         holder.binding.root.setOnClickListener {

--- a/app/src/main/java/social/entourage/android/home/HomeSmallTalkAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeSmallTalkAdapter.kt
@@ -31,9 +31,9 @@ class HomeSmallTalkAdapter(
 ) : ListAdapter<HomeSmallTalkItem, RecyclerView.ViewHolder>(DiffCallback()) {
 
     companion object {
-        private const val TYPE_MATCH = 0
-        private const val TYPE_WAITING = 1
-        private const val TYPE_CONVERSATION = 2
+        private val TYPE_MATCH = R.layout.item_home_small_talk_match
+        private val TYPE_WAITING = R.layout.item_home_small_talk_waiting
+        private val TYPE_CONVERSATION = R.layout.item_home_small_talk_conversation
     }
 
     override fun getItemViewType(position: Int): Int {


### PR DESCRIPTION
Fixed a `ClassCastException` where `HomeInitialPedagoAdapter.PedagoViewHolder` was being cast to `HomeEventAdapter.EventViewHolder`. This happened because multiple adapters sharing a `RecycledViewPool` were using the default view type (0).

Changes:
- `HomeInitialPedagoAdapter`: Overridden `getItemViewType` to return `R.layout.home_v2_initial_pedago_item_layout`.
- `HomeEventAdapter`: Overridden `getItemViewType` to return `R.layout.home_v2_event_item_layout`.
- `HomeGroupAdapter`: Overridden `getItemViewType` to return `R.layout.home_v2_group_item_layout`.
- `HomeSmallTalkAdapter`: Updated internal constants `TYPE_MATCH`, `TYPE_WAITING`, `TYPE_CONVERSATION` to use layout resource IDs instead of 0, 1, 2.

---
*PR created automatically by Jules for task [9134179085361569030](https://jules.google.com/task/9134179085361569030) started by @clemPerrousset*