### PR TITLE
Fix: Enable unsubscribe option in event settings for newly joined events from Discover list

### DIFF
--- a/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
@@ -219,14 +219,23 @@ class DetailConversationActivity : CommentActivity() {
             }
 
             // On passe TOUS les arguments nécessaires (comme dans EventFeedFragment)
-            ActionSheetFragment.newEvent(
-                eventId = eventId,
-                conversationId = if (isSmallTalkMode) smallTalkId.toIntOrNull() ?: 0 else id,
-                canManageParticipants = false, // À adapter selon ta logique métier
-                eventTitle = event?.title ?: "",
-                participantsCount = event?.membersCount ?: 0,
-                eventAddress = event?.metadata?.displayAddress ?: ""
-            ).show(supportFragmentManager, "ActionSheetFragment")
+            val sheet = event?.let { ev ->
+                ActionSheetFragment.newEvent(
+                    event = ev,
+                    conversationId = if (isSmallTalkMode) smallTalkId.toIntOrNull() ?: 0 else id,
+                    canManageParticipants = false // À adapter selon ta logique métier
+                )
+            } ?: run {
+                ActionSheetFragment.newEvent(
+                    eventId = eventId,
+                    conversationId = if (isSmallTalkMode) smallTalkId.toIntOrNull() ?: 0 else id,
+                    canManageParticipants = false, // À adapter selon ta logique métier
+                    eventTitle = event?.title ?: "",
+                    participantsCount = event?.membersCount ?: 0,
+                    eventAddress = event?.metadata?.displayAddress ?: ""
+                )
+            }
+            sheet.show(supportFragmentManager, "ActionSheetFragment")
 
         } else {
             // Pour les autres modes (GROUP, DISCUSSION_ONE_TO_ONE, DISCUSSION_GROUP)

--- a/app/src/main/java/social/entourage/android/report/ActionSheetFragment.kt
+++ b/app/src/main/java/social/entourage/android/report/ActionSheetFragment.kt
@@ -289,8 +289,11 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
         }
 
         // remove if not part of event
-        if (EventFeedActivity.isFromMyEvent == false && mode == SheetMode.EVENT) {
-            binding.quit.profileSettingsItemLayout.isVisible = false
+        if (mode == SheetMode.EVENT) {
+            val isMember = eventObj?.member ?: EventFeedActivity.isFromMyEvent
+            if (!isMember) {
+                binding.quit.profileSettingsItemLayout.isVisible = false
+            }
         }
     }
 


### PR DESCRIPTION
The "Leave event" option was hidden in the event settings menu if the user navigated from the "Discover" list, even if they had joined the event. This was because the visibility logic relied on `EventFeedActivity.isFromMyEvent`, which is false for the Discover list.

I updated `ActionSheetFragment.kt` to check `eventObj?.member` first. If the event object is present, its `member` field (which is updated upon joining) is used to determine visibility. The old logic is kept as a fallback.

I also updated `DetailConversationActivity.kt` to use the `ActionSheetFragment.newEvent` overload that accepts the `Events` object, so that the fix also applies when accessing settings from a conversation detail view.

---
*PR created automatically by Jules for task [15534276687088356770](https://jules.google.com/task/15534276687088356770) started by @clemPerrousset*