### PR TITLE
Add female-only event info bubble

### DIFF
--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
@@ -92,7 +92,7 @@ class CreateEventStepTwoFragment : Fragment() {
     private fun setReservedFemale() {
         binding.layout.switchReservedFemale.setOnCheckedChangeListener { _, isChecked ->
             CommunicationHandler.event.reserved_female = isChecked
-            binding.root.findViewById<View>(R.id.layout_reserved_female_info).visibility = if (isChecked) View.VISIBLE else View.GONE
+            binding.root.findViewById<View>(R.id.layout_reserved_female_info)?.visibility = if (isChecked) View.VISIBLE else View.GONE
         }
     }
 
@@ -205,7 +205,7 @@ class CreateEventStepTwoFragment : Fragment() {
                 })
                 binding.layout.switchReservedFemale.isChecked = this.reserved_female ?: false
                 CommunicationHandler.event.reserved_female = this.reserved_female ?: false
-                binding.root.findViewById<View>(R.id.layout_reserved_female_info).visibility = if (this.reserved_female == true) View.VISIBLE else View.GONE
+                binding.root.findViewById<View>(R.id.layout_reserved_female_info)?.visibility = if (this.reserved_female == true) View.VISIBLE else View.GONE
             }
         }
     }

--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
@@ -92,6 +92,7 @@ class CreateEventStepTwoFragment : Fragment() {
     private fun setReservedFemale() {
         binding.layout.switchReservedFemale.setOnCheckedChangeListener { _, isChecked ->
             CommunicationHandler.event.reserved_female = isChecked
+            binding.layout.layoutReservedFemaleInfo.visibility = if (isChecked) View.VISIBLE else View.GONE
         }
     }
 
@@ -204,6 +205,7 @@ class CreateEventStepTwoFragment : Fragment() {
                 })
                 binding.layout.switchReservedFemale.isChecked = this.reserved_female ?: false
                 CommunicationHandler.event.reserved_female = this.reserved_female ?: false
+                binding.layout.layoutReservedFemaleInfo.visibility = if (this.reserved_female == true) View.VISIBLE else View.GONE
             }
         }
     }

--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
@@ -92,7 +92,7 @@ class CreateEventStepTwoFragment : Fragment() {
     private fun setReservedFemale() {
         binding.layout.switchReservedFemale.setOnCheckedChangeListener { _, isChecked ->
             CommunicationHandler.event.reserved_female = isChecked
-            binding.layout.layoutReservedFemaleInfo.visibility = if (isChecked) View.VISIBLE else View.GONE
+            binding.layout.root.findViewById<View>(R.id.layout_reserved_female_info).visibility = if (isChecked) View.VISIBLE else View.GONE
         }
     }
 
@@ -205,7 +205,7 @@ class CreateEventStepTwoFragment : Fragment() {
                 })
                 binding.layout.switchReservedFemale.isChecked = this.reserved_female ?: false
                 CommunicationHandler.event.reserved_female = this.reserved_female ?: false
-                binding.layout.layoutReservedFemaleInfo.visibility = if (this.reserved_female == true) View.VISIBLE else View.GONE
+                binding.layout.root.findViewById<View>(R.id.layout_reserved_female_info).visibility = if (this.reserved_female == true) View.VISIBLE else View.GONE
             }
         }
     }

--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
@@ -92,7 +92,7 @@ class CreateEventStepTwoFragment : Fragment() {
     private fun setReservedFemale() {
         binding.layout.switchReservedFemale.setOnCheckedChangeListener { _, isChecked ->
             CommunicationHandler.event.reserved_female = isChecked
-            binding.layout.root.findViewById<View>(R.id.layout_reserved_female_info).visibility = if (isChecked) View.VISIBLE else View.GONE
+            binding.root.findViewById<View>(R.id.layout_reserved_female_info).visibility = if (isChecked) View.VISIBLE else View.GONE
         }
     }
 
@@ -205,7 +205,7 @@ class CreateEventStepTwoFragment : Fragment() {
                 })
                 binding.layout.switchReservedFemale.isChecked = this.reserved_female ?: false
                 CommunicationHandler.event.reserved_female = this.reserved_female ?: false
-                binding.layout.root.findViewById<View>(R.id.layout_reserved_female_info).visibility = if (this.reserved_female == true) View.VISIBLE else View.GONE
+                binding.root.findViewById<View>(R.id.layout_reserved_female_info).visibility = if (this.reserved_female == true) View.VISIBLE else View.GONE
             }
         }
     }

--- a/app/src/main/res/drawable/bg_info_bubble_beige.xml
+++ b/app/src/main/res/drawable/bg_info_bubble_beige.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/beige_clair" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/orange_light_separator_event" />
+    <corners android:radius="14dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_info_orange_outlined.xml
+++ b/app/src/main/res/drawable/ic_info_orange_outlined.xml
@@ -1,0 +1,17 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#00000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z"
+        android:strokeWidth="1.5"
+        android:strokeColor="#FF9739"/>
+    <path
+        android:fillColor="#FF9739"
+        android:pathData="M11,10h2v7h-2z"/>
+    <path
+        android:fillColor="#FF9739"
+        android:pathData="M11,7h2v2h-2z"/>
+</vector>

--- a/app/src/main/res/layout/layout_edit_event_step_two.xml
+++ b/app/src/main/res/layout/layout_edit_event_step_two.xml
@@ -114,6 +114,33 @@
                 app:trackTint="@color/light_orange_opacity_50" />
         </LinearLayout>
 
+        <LinearLayout
+            android:id="@+id/layout_reserved_female_info"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:orientation="horizontal"
+            android:background="@drawable/bg_info_bubble_beige"
+            android:padding="15dp"
+            android:gravity="center_vertical"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@+id/layout_reserved_female">
+
+            <ImageView
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/ic_info_orange_outlined" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="15dp"
+                android:fontFamily="@font/nunitosans_regular"
+                android:textColor="@color/black"
+                android:textSize="14sp"
+                android:text="@string/event_reserved_female_info" />
+        </LinearLayout>
+
         <include
             android:id="@+id/error"
             layout="@layout/new_error"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -427,6 +427,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="event_places">Nombre de places</string>
     <string name="event_reserved_female_question">Cet événement est-il réservé aux femmes ?</string>
     <string name="event_reserved_female_banner">Cet événement est réservé aux femmes</string>
+    <string name="event_reserved_female_info">L\'événement sera uniquement visible par les utilisatrices de l\'application.</string>
     <string name="event_canceled">Evénement annulé</string>
     <string name="member_since">Membre Entourage depuis</string>
     <string name="profile_date_format">MM/yyyy</string>


### PR DESCRIPTION
Added a conditional info bubble below the "Reserved for women" switch in the event creation flow (Step 2). The bubble explains that the event will only be visible to female users. It is visible only when the switch is ON.

---
*PR created automatically by Jules for task [15245265957541626572](https://jules.google.com/task/15245265957541626572) started by @clemPerrousset*