### PR TITLE
Revamp Home screen with new SmallTalk UI and Tools section

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -121,14 +121,14 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
     private lateinit var groupButtonAdapter: HomeSectionButtonAdapter
 
     // Map & Hors Zone
-    private lateinit var mapHeaderAdapter: HomeSectionHeaderAdapter
-    private lateinit var mapSingleViewAdapter: HomeSingleLayoutAdapter
     private lateinit var horsZoneAdapter: HomeSingleLayoutAdapter
+
+    // Tools
+    private lateinit var homeToolsAdapter: HomeToolsAdapter
 
     // Pedago
     private lateinit var pedagoHeaderAdapter: HomeSectionHeaderAdapter
     private lateinit var homePedagoAdapter: HomePedagoAdapter
-    private lateinit var pedagoButtonAdapter: HomeSectionButtonAdapter
 
     // Help
     private lateinit var helpHeaderAdapter: HomeSectionHeaderAdapter
@@ -331,16 +331,29 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
         }
         horsZoneAdapter.setVisible(false)
 
-        mapHeaderAdapter = HomeSectionHeaderAdapter()
-        mapSingleViewAdapter = HomeSingleLayoutAdapter(R.layout.home_map_card) { view ->
-            view.findViewById<View>(R.id.home_button_map).setOnClickListener {
+        // 7. Tools
+        homeToolsAdapter = HomeToolsAdapter(requireContext(),
+            onMapClick = {
                 AnalyticsEvents.logEvent(AnalyticsEvents.Action__Home__Map)
                 val intent = Intent(requireContext(), GDSMainActivity::class.java)
                 startActivityForResult(intent, 0)
+            },
+            onPedagoClick = {
+                AnalyticsEvents.logEvent(AnalyticsEvents.Action__Home__Pedago)
+                val intent = Intent(requireActivity(), PedagoListActivity::class.java)
+                requireContext().startActivity(intent)
+                requireActivity().overridePendingTransition(
+                    R.anim.slide_in_right,
+                    R.anim.slide_out_left
+                )
+            },
+            onCharterClick = {
+                val chartIntent = Intent(Intent.ACTION_VIEW, android.net.Uri.parse(getString(R.string.disclaimer_link_public)))
+                requireContext().startActivity(chartIntent)
             }
-        }
+        )
 
-        // 7. Pedago
+        // 8. Pedago
         pedagoHeaderAdapter = HomeSectionHeaderAdapter()
         homePedagoAdapter = HomePedagoAdapter(object : OnItemClick {
             override fun onItemClick(pedagogicalContent: Pedago) {
@@ -356,15 +369,6 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
                 }
             }
         })
-        pedagoButtonAdapter = HomeSectionButtonAdapter {
-            AnalyticsEvents.logEvent(AnalyticsEvents.Action__Home__Pedago)
-            val intent = Intent(requireActivity(), PedagoListActivity::class.java)
-            requireContext().startActivity(intent)
-            requireActivity().overridePendingTransition(
-                R.anim.slide_in_right,
-                R.anim.slide_out_left
-            )
-        }
 
         // 8. Help
         helpHeaderAdapter = HomeSectionHeaderAdapter()
@@ -383,6 +387,9 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
             initialPedagoWrapperAdapter,
             smallTalkHeaderAdapter,
             smallTalkWrapperAdapter,
+            homeToolsAdapter,
+            pedagoHeaderAdapter,
+            homePedagoAdapter,
             actionHeaderAdapter,
             homeActionAdapter,
             actionButtonAdapter,
@@ -393,11 +400,6 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
             groupWrapperAdapter,
             groupButtonAdapter,
             horsZoneAdapter,
-            mapHeaderAdapter,
-            mapSingleViewAdapter,
-            pedagoHeaderAdapter,
-            homePedagoAdapter,
-            pedagoButtonAdapter,
             helpHeaderAdapter,
             homeHelpAdapter
         )
@@ -411,8 +413,6 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
             visibility = View.VISIBLE
         }
 
-        // On masque la map via l'adapter plutôt que la vue entière pour garder le layout stable
-        mapHeaderAdapter.update(getString(R.string.home_title_map), getString(R.string.home_subtitle_map), true)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -809,7 +809,7 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
 
         val pedagos: MutableList<Pedago> = mutableListOf()
         for (pedago in allPedago) {
-            if (pedagos.size > 1) {
+            if (pedagos.size > 2) {
                 break
             }
             if (pedago.watched == false) {
@@ -835,7 +835,6 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
 
         val show = allPedago.isNotEmpty()
         pedagoHeaderAdapter.update(getString(R.string.home_title_pedago), getString(R.string.home_subtitle_pedago), show)
-        pedagoButtonAdapter.update(getString(R.string.home_btn_more_pedago), show)
     }
 
     private fun updateContributionsView(summary: Summary) {

--- a/app/src/main/java/social/entourage/android/home/HomeToolsAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeToolsAdapter.kt
@@ -1,0 +1,30 @@
+package social.entourage.android.home
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import social.entourage.android.databinding.LayoutHomeToolsBinding
+
+class HomeToolsAdapter(
+    private val context: Context,
+    private val onMapClick: () -> Unit,
+    private val onPedagoClick: () -> Unit,
+    private val onCharterClick: () -> Unit
+) : RecyclerView.Adapter<HomeToolsAdapter.ToolsViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ToolsViewHolder {
+        val binding = LayoutHomeToolsBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ToolsViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ToolsViewHolder, position: Int) {
+        holder.binding.cardToolsMap.setOnClickListener { onMapClick() }
+        holder.binding.cardToolsPedago.setOnClickListener { onPedagoClick() }
+        holder.binding.cardToolsCharter.setOnClickListener { onCharterClick() }
+    }
+
+    override fun getItemCount(): Int = 1
+
+    class ToolsViewHolder(val binding: LayoutHomeToolsBinding) : RecyclerView.ViewHolder(binding.root)
+}

--- a/app/src/main/res/drawable/bg_home_tool_card.xml
+++ b/app/src/main/res/drawable/bg_home_tool_card.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@android:color/white"/>
+    <corners android:radius="20dp"/>
+</shape>

--- a/app/src/main/res/drawable/bg_home_tool_icon.xml
+++ b/app/src/main/res/drawable/bg_home_tool_icon.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="#FEF5EB"/>
+</shape>

--- a/app/src/main/res/layout/home_v2_pedago_item_layout.xml
+++ b/app/src/main/res/layout/home_v2_pedago_item_layout.xml
@@ -8,6 +8,7 @@
     android:layout_marginStart="@dimen/entourage_marginstart"
     android:layout_marginEnd="@dimen/entourage_margin_end"
     android:layout_marginTop="@dimen/entourage_little_margin_top">
+
     <ImageView
         android:layout_width="90dp"
         android:layout_height="match_parent"
@@ -19,13 +20,14 @@
         android:scaleType="centerCrop"
         tools:src="@drawable/placeholder_user"
         />
+
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/tv_tag_pedago_item"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toEndOf="@+id/iv_pedago_item"
-        android:layout_marginTop="@dimen/entourage_little_margin_top"
+        android:layout_marginTop="16dp"
         android:layout_marginStart="@dimen/entourage_margin_start_inner_item"
         android:background="@drawable/home_v2_tv_tag_item_pedago_shape"
         android:textColor="@color/light_orange"
@@ -39,6 +41,21 @@
         />
 
     <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/tv_lenght_pedago_item"
+        app:layout_constraintStart_toEndOf="@+id/tv_tag_pedago_item"
+        app:layout_constraintTop_toTopOf="@+id/tv_tag_pedago_item"
+        app:layout_constraintBottom_toBottomOf="@+id/tv_tag_pedago_item"
+        android:layout_marginStart="8dp"
+        android:textColor="@color/grey"
+        android:textSize="@dimen/entourage_font_very_small"
+        android:fontFamily="@font/nunitosans_regular"
+        android:drawableStart="@drawable/new_time_grey"
+        android:drawablePadding="4dp"
+        tools:text="cette video dure 6 min"/>
+
+    <TextView
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:id="@+id/tv_title_item_pedago"
@@ -46,24 +63,13 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tv_tag_pedago_item"
         android:layout_marginStart="@dimen/entourage_margin_start_inner_item"
-        android:layout_marginTop="@dimen/entourage_little_margin_five"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
         android:textSize="@dimen/entourage_font_small"
         android:textColor="@color/black"
         android:fontFamily="@font/quicksand_bold"
         android:maxLines="2"
+        android:ellipsize="end"
         tools:text="un super titre pour ma carte pedago pour tester si elle passe bien"/>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/tv_lenght_pedago_item"
-        app:layout_constraintStart_toEndOf="@+id/iv_pedago_item"
-        app:layout_constraintBottom_toBottomOf="parent"
-        android:layout_marginBottom="@dimen/entourage_margin_bottom"
-        android:layout_marginStart="@dimen/entourage_margin_start_inner_item"
-        android:textColor="@color/grey"
-        android:textSize="@dimen/entourage_font_very_small"
-        android:fontFamily="@font/nunitosans_regular"
-        tools:text="cette video dure 6 min"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_home_small_talk_match.xml
+++ b/app/src/main/res/layout/item_home_small_talk_match.xml
@@ -13,9 +13,22 @@
         android:layout_width="70dp"
         android:layout_height="70dp"
         android:src="@drawable/ic_home_search_small_talk"
-        app:layout_constraintTop_toTopOf="@+id/tv_home_small_talk_subtitle_match"
-        app:layout_constraintBottom_toBottomOf="@+id/button_start"
+        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_home_small_talk_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/home_title_small_talk"
+        android:fontFamily="@font/quicksand_bold"
+        android:textSize="16sp"
+        android:textColor="@color/black"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/iv_home_small_talk_icon_match"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="16dp"
+        />
 
     <TextView
         android:id="@+id/tv_home_small_talk_subtitle_match"
@@ -25,30 +38,30 @@
         android:fontFamily="@font/nunitosans_regular"
         android:textSize="14sp"
         android:textColor="@color/grey_dark"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toEndOf="@id/iv_home_small_talk_icon_match"
+        app:layout_constraintTop_toBottomOf="@+id/tv_home_small_talk_title"
+        app:layout_constraintStart_toEndOf="@+id/iv_home_small_talk_icon_match"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginTop="4dp"
-        android:layout_marginStart="10dp"
-        android:layout_marginEnd="10dp"/>
+        android:layout_marginTop="8dp"
+        android:layout_marginStart="16dp"
+        />
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/button_start"
-        style="?android:attr/borderlessButtonStyle"
         android:layout_width="wrap_content"
-        android:layout_height="47dp"
-        android:layout_weight="1"
-        android:background="@drawable/shape_button_v9_positive"
-        android:elevation="0dp"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/orange"
+        app:cornerRadius="32dp"
         android:fontFamily="@font/quicksand_bold"
-        android:paddingVertical="5dp"
+        android:paddingVertical="10dp"
+        android:paddingHorizontal="24dp"
         android:text="@string/small_talk_button_match"
         android:textAllCaps="false"
+        app:icon="@drawable/ic_bottom_navigation_active_messages"
+        app:iconTint="@color/white"
         app:layout_constraintTop_toBottomOf="@+id/tv_home_small_talk_subtitle_match"
-        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         android:textColor="@android:color/white"
-        android:layout_marginTop="10dp"
+        android:layout_marginTop="16dp"
         android:textSize="14sp" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_home_tools.xml
+++ b/app/src/main/res/layout/layout_home_tools.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:paddingTop="20dp"
+    android:paddingBottom="20dp">
+
+    <TextView
+        android:id="@+id/tv_home_tools_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/home_title_tools"
+        android:fontFamily="@font/quicksand_bold"
+        android:textSize="18sp"
+        android:textColor="@color/black"
+        android:layout_marginBottom="12dp"
+        />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:baselineAligned="false">
+
+        <!-- Card 1: Map -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/card_tools_map"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/bg_home_tool_card"
+            android:padding="12dp"
+            android:layout_marginEnd="8dp"
+            android:minHeight="140dp">
+
+            <ImageView
+                android:id="@+id/iv_tools_map_bg"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="@drawable/bg_home_tool_icon"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:padding="10dp"
+                android:src="@drawable/home_map_button_illu"/>
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/home_tools_map"
+                android:fontFamily="@font/quicksand_bold"
+                android:textSize="14sp"
+                android:textColor="@color/black"
+                android:textAlignment="center"
+                android:gravity="center"
+                app:layout_constraintTop_toBottomOf="@+id/iv_tools_map_bg"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:layout_marginTop="8dp"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <!-- Card 2: Pedago -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/card_tools_pedago"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/bg_home_tool_card"
+            android:padding="12dp"
+            android:layout_marginEnd="8dp"
+            android:minHeight="140dp">
+
+            <ImageView
+                android:id="@+id/iv_tools_pedago_bg"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="@drawable/bg_home_tool_icon"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:padding="10dp"
+                android:src="@drawable/ic_book"/>
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/home_tools_pedago"
+                android:fontFamily="@font/quicksand_bold"
+                android:textSize="14sp"
+                android:textColor="@color/black"
+                android:textAlignment="center"
+                android:gravity="center"
+                app:layout_constraintTop_toBottomOf="@+id/iv_tools_pedago_bg"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:layout_marginTop="8dp"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <!-- Card 3: Charter -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/card_tools_charter"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@drawable/bg_home_tool_card"
+            android:padding="12dp"
+            android:minHeight="140dp">
+
+            <ImageView
+                android:id="@+id/iv_tools_charter_bg"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:background="@drawable/bg_home_tool_icon"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:padding="10dp"
+                android:src="@drawable/ic_chartes_rules"
+                app:tint="@color/orange"/>
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/home_tools_charter"
+                android:fontFamily="@font/quicksand_bold"
+                android:textSize="14sp"
+                android:textColor="@color/black"
+                android:textAlignment="center"
+                android:gravity="center"
+                app:layout_constraintTop_toBottomOf="@+id/iv_tools_charter_bg"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                android:layout_marginTop="8dp"/>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3237,4 +3237,10 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="birthday_button">Revenir à la page d\'accueil</string>
 
     <string name="guide_help_orientation_button">Aide &amp; orientation</string>
+
+    <!-- Home Tools -->
+    <string name="home_title_tools">Tes outils solidaires</string>
+    <string name="home_tools_map">Carte des lieux solidaires</string>
+    <string name="home_tools_pedago">Contenus pour apprendre et agir</string>
+    <string name="home_tools_charter">Charte éthique Entourage</string>
 </resources>


### PR DESCRIPTION
This change updates the Home screen by revamping the SmallTalk card, introducing a new "Tools" section with shortcuts to Map, Pedagogical content, and Charter, and reorganizing the Pedagogical content list below these tools. Old navigation buttons for Map and Pedago have been removed.

---
*PR created automatically by Jules for task [13972896598816499270](https://jules.google.com/task/13972896598816499270) started by @clemPerrousset*