### PR TITLE
Reorder Home sections and remove Pedago header

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -385,11 +385,6 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
             config,
             initialPedagoHeaderAdapter,
             initialPedagoWrapperAdapter,
-            smallTalkHeaderAdapter,
-            smallTalkWrapperAdapter,
-            homeToolsAdapter,
-            pedagoHeaderAdapter,
-            homePedagoAdapter,
             actionHeaderAdapter,
             homeActionAdapter,
             actionButtonAdapter,
@@ -400,6 +395,10 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
             groupWrapperAdapter,
             groupButtonAdapter,
             horsZoneAdapter,
+            smallTalkHeaderAdapter,
+            smallTalkWrapperAdapter,
+            homeToolsAdapter,
+            homePedagoAdapter,
             helpHeaderAdapter,
             homeHelpAdapter
         )
@@ -834,7 +833,6 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
         homePresenter.getSummary()
 
         val show = allPedago.isNotEmpty()
-        pedagoHeaderAdapter.update(getString(R.string.home_title_pedago), getString(R.string.home_subtitle_pedago), show)
     }
 
     private fun updateContributionsView(summary: Summary) {


### PR DESCRIPTION
Move Smalltalk, Tools, and Pedago list to the bottom of the Home screen (above Moderator). Remove the "Tout savoir pour passer à l'action" header.

---
*PR created automatically by Jules for task [14685485592854686577](https://jules.google.com/task/14685485592854686577) started by @clemPerrousset*