### PR TITLE
Update event list date format to include time

### DIFF
--- a/app/src/main/java/social/entourage/android/discussions/DiscussionsMainFragment.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DiscussionsMainFragment.kt
@@ -416,7 +416,7 @@ class DiscussionsMainFragment : Fragment() {
             },
             title = (m.name),
             imageUrl = m.imageUrl,
-            subname = m.getParsedDate()?.let { Utils.formatEventDateShort(it, requireContext()) } ?: "",
+            subname = m.getParsedDate()?.let { Utils.formatEventDateWithTime(it, requireContext()) } ?: "",
             lastMessage = lastMessage,
             numberUnreadMessages = m.numberOfUnreadMessages ?: 0,
             memberCount = m.numberOfPeople ?: 0

--- a/app/src/main/java/social/entourage/android/events/list/AllEventAdapter.kt
+++ b/app/src/main/java/social/entourage/android/events/list/AllEventAdapter.kt
@@ -82,7 +82,7 @@ class AllEventAdapter(var userId: Int?, var context: Context) :
             }
             holder.binding.eventName.text = event.title
             event.metadata?.startsAt?.let {
-                holder.binding.date.text = Utils.formatEventDateShort(it, context)
+                holder.binding.date.text = Utils.formatEventDateWithTime(it, context)
             }
             holder.binding.location.text = event.metadata?.displayAddress
             holder.binding.participants.text = event.membersCount.toString()

--- a/app/src/main/java/social/entourage/android/groups/details/feed/GroupEventsAdapter.kt
+++ b/app/src/main/java/social/entourage/android/groups/details/feed/GroupEventsAdapter.kt
@@ -41,7 +41,7 @@ class GroupEventsAdapter(
         holder.binding.name.text = eventsList[position].title
         holder.binding.address.text = eventsList[position].metadata?.placeName
         eventsList[position].metadata?.startsAt?.let {
-            holder.binding.date.text = Utils.formatEventDateShort(it, context)
+            holder.binding.date.text = Utils.formatEventDateWithTime(it, context)
         }
         eventsList[position].metadata?.landscapeUrl?.let {
             Glide.with(holder.itemView.context)

--- a/app/src/main/java/social/entourage/android/home/HomeEventAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeEventAdapter.kt
@@ -163,7 +163,7 @@ class HomeEventAdapter(
         }
 
         event.metadata?.startsAt?.let {
-            holder.binding.tvDateHomeV2EventItem.text = Utils.formatEventDateShort(it, context)
+            holder.binding.tvDateHomeV2EventItem.text = Utils.formatEventDateWithTime(it, context)
         }
         event.interests.let {
             if (it.isNotEmpty()) {

--- a/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
+++ b/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
@@ -381,6 +381,30 @@ object Utils {
         return SimpleDateFormat(pattern, locale).format(date).replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
     }
 
+    fun formatEventDateWithTime(date: Date, context: Context): String {
+        val locale = LanguageManager.getLocaleFromPreferences(context)
+        val cal = Calendar.getInstance()
+        cal.time = date
+        val now = Calendar.getInstance()
+
+        val timeStr = SimpleDateFormat("HH:mm", locale).format(date)
+
+        if (cal.get(Calendar.YEAR) == now.get(Calendar.YEAR) &&
+            cal.get(Calendar.DAY_OF_YEAR) == now.get(Calendar.DAY_OF_YEAR)) {
+            return "${context.getString(R.string.date_today)}, $timeStr"
+        }
+
+        val tomorrow = Calendar.getInstance()
+        tomorrow.add(Calendar.DAY_OF_YEAR, 1)
+        if (cal.get(Calendar.YEAR) == tomorrow.get(Calendar.YEAR) &&
+            cal.get(Calendar.DAY_OF_YEAR) == tomorrow.get(Calendar.DAY_OF_YEAR)) {
+            return "${context.getString(R.string.date_tomorrow)}, $timeStr"
+        }
+
+        val pattern = "EEE d MMM, HH:mm"
+        return SimpleDateFormat(pattern, locale).format(date).replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+    }
+
     fun formatEventDateLong(date: Date, context: Context): String {
         val locale = LanguageManager.getLocaleFromPreferences(context)
         val cal = Calendar.getInstance()

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1447,6 +1447,7 @@
     <string name="other">Other</string>
     <string name="date_today">Today</string>
     <string name="date_today_lower">today</string>
+    <string name="date_tomorrow">Tomorrow</string>
     <string name="date_format">%1$d %2$s %3$d</string>
     <string name="date_format_short">%1$d %2$s</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -2360,6 +2360,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="other">Autre</string>
     <string name="date_today">Aujourd\'hui</string>
     <string name="date_today_lower">aujourd\'hui</string>
+    <string name="date_tomorrow">Demain</string>
     <string name="date_format">%1$d %2$s %3$d</string>
     <string name="date_format_short">%1$d %2$s</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2579,6 +2579,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="other">Autre</string>
     <string name="date_today">Aujourd\'hui</string>
     <string name="date_today_lower">aujourd\'hui</string>
+    <string name="date_tomorrow">Demain</string>
     <string name="date_format">%1$d %2$s %3$d</string>
     <string name="date_format_short">%1$d %2$s</string>
 


### PR DESCRIPTION
Updated the date format in Home, Discussion List, and Event List to include the time (e.g., "Jeu. 12 Fév., 9:00") while preserving special "Aujourd'hui" and "Demain" logic. The Event Detail view remains unchanged as requested.

---
*PR created automatically by Jules for task [11555779398464262396](https://jules.google.com/task/11555779398464262396) started by @clemPerrousset*