### PR TITLE
Fix navigation after leaving a conversation

### DIFF
--- a/app/src/main/java/social/entourage/android/discussions/DiscussionsMainFragment.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DiscussionsMainFragment.kt
@@ -88,14 +88,14 @@ class DiscussionsMainFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         // IMPORTANT : on ne recharge pas si on revient du détail ; on consomme le flag ici
-        if (isFromDetail) {
-            isFromDetail = false
-        } else {
-            reloadFromStart()
-        }
         if (RefreshController.shouldRefreshFragment) {
             RefreshController.shouldRefreshFragment = false
             isFromRefresh = true
+            reloadFromStart()
+        } else if (isFromDetail) {
+            isFromDetail = false
+        } else {
+            reloadFromStart()
         }
         discussionsPresenter.getUnreadCount()
         checkNotificationsState()

--- a/app/src/main/java/social/entourage/android/report/ActionSheetFragment.kt
+++ b/app/src/main/java/social/entourage/android/report/ActionSheetFragment.kt
@@ -11,6 +11,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import social.entourage.android.EntourageApplication
+import social.entourage.android.RefreshController
 import social.entourage.android.R
 import social.entourage.android.api.model.Events
 import social.entourage.android.databinding.NewFragmentSettingsDiscussionModalBinding
@@ -127,6 +128,24 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         configureUI()
         setupClicks()
+        setupObservers()
+    }
+
+    private fun setupObservers() {
+        discussionPresenter.hasUserLeftConversation.observe(viewLifecycleOwner) { hasLeft ->
+            if (hasLeft) {
+                RefreshController.shouldRefreshFragment = true
+                dismiss()
+                activity?.finish()
+            }
+        }
+        smallTalkViewModel.shouldLeave.observe(viewLifecycleOwner) { hasLeft ->
+            if (hasLeft) {
+                RefreshController.shouldRefreshFragment = true
+                dismiss()
+                activity?.finish()
+            }
+        }
     }
 
     private fun configureUI() {
@@ -502,7 +521,6 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
                             getString(R.string.exit)
                         ) {
                             smallTalkViewModel.leaveSmallTalk(smallTalkId.toString())
-                            dismiss()
                         }
                     } else {
                         CustomAlertDialog.showWithCancelFirst(
@@ -512,7 +530,6 @@ class ActionSheetFragment : BottomSheetDialogFragment() {
                             getString(R.string.exit)
                         ) {
                             discussionPresenter.leaveConverstion(conversationId)
-                            dismiss()
                         }
                     }
                 }


### PR DESCRIPTION
This PR fixes the issue where leaving a conversation did not redirect the user back to the discussion list.
It modifies `ActionSheetFragment.kt` to wait for the API response before closing the activity, and updates `DiscussionsMainFragment.kt` to handle the refresh flag correctly.

---
*PR created automatically by Jules for task [2140845858649354979](https://jules.google.com/task/2140845858649354979) started by @clemPerrousset*