### PR TITLE
Update event date format in details view

### DIFF
--- a/app/src/main/java/social/entourage/android/events/details/feed/AboutEventFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/details/feed/AboutEventFragment.kt
@@ -140,7 +140,7 @@ class AboutEventFragment : Fragment(), OnMapReadyCallback {
                 binding.dateStartsAt.content.text =
                     String.format(
                         getString(R.string.date_recurrence_event),
-                        Utils.formatEventDateLong(it, requireContext()), recurrence
+                        Utils.formatEventDateForDisplay(it, requireContext()), recurrence
                     )
             }
             event?.metadata?.let {

--- a/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
+++ b/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
@@ -413,4 +413,31 @@ object Utils {
         val pattern = "EEEE d MMMM"
         return SimpleDateFormat(pattern, locale).format(date).replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
     }
+
+    fun formatEventDateForDisplay(date: Date, context: Context): String {
+        val locale = LanguageManager.getLocaleFromPreferences(context)
+        val cal = Calendar.getInstance()
+        cal.time = date
+        val now = Calendar.getInstance()
+
+        if (cal.get(Calendar.YEAR) == now.get(Calendar.YEAR) &&
+            cal.get(Calendar.DAY_OF_YEAR) == now.get(Calendar.DAY_OF_YEAR)) {
+            return context.getString(R.string.date_today)
+        }
+
+        val tomorrow = Calendar.getInstance()
+        tomorrow.add(Calendar.DAY_OF_YEAR, 1)
+        if (cal.get(Calendar.YEAR) == tomorrow.get(Calendar.YEAR) &&
+            cal.get(Calendar.DAY_OF_YEAR) == tomorrow.get(Calendar.DAY_OF_YEAR)) {
+            return context.getString(R.string.date_tomorrow)
+        }
+
+        val pattern = if (cal.get(Calendar.YEAR) == now.get(Calendar.YEAR)) {
+            "EEEE d MMMM"
+        } else {
+            "EEEE d MMMM yyyy"
+        }
+
+        return SimpleDateFormat(pattern, locale).format(date).replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
+    }
 }


### PR DESCRIPTION
This change updates the date display format in the event details view (`AboutEventFragment`). It now uses `Utils.formatEventDateForDisplay` which intelligently displays "Aujourd'hui" or "Demain" for current and next day events, and falls back to a full date format (with year if not current year) for other dates. This aligns the detail view date format with the list view format as requested.

---
*PR created automatically by Jules for task [1030191381217564067](https://jules.google.com/task/1030191381217564067) started by @clemPerrousset*