### PR TITLE
Fix date and time formatting in event feed

### DIFF
--- a/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
@@ -312,20 +312,21 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
                 )
             }
             event?.metadata?.startsAt?.let {
-                binding.dateStartsAt.content.text = SimpleDateFormat(
-                    context?.getString(R.string.feed_event_date),
-                    locale
-                ).format(
-                    it
+                binding.dateStartsAt.content.text = Utils.formatEventDateForDisplay(
+                    it,
+                    requireContext()
                 )
             }
-            event?.metadata?.startsAt?.let {
-                binding.time.content.text = SimpleDateFormat(
-                    context?.getString(R.string.feed_event_time),
-                    locale
-                ).format(
-                    it
-                )
+            event?.metadata?.startsAt?.let { startsAt ->
+                val endsAt = event?.metadata?.endsAt
+                val timeFormat = SimpleDateFormat(context?.getString(R.string.feed_event_time), locale)
+                val startTime = timeFormat.format(startsAt)
+                binding.time.content.text = if (endsAt != null) {
+                    val endTime = timeFormat.format(endsAt)
+                    "$startTime - $endTime"
+                } else {
+                    startTime
+                }
             }
             initializeMembersPhotos()
             initializeInterests()


### PR DESCRIPTION
This PR updates the date and time display in `EventFeedFragment`.

**Changes:**
- The date display logic has been replaced to use `Utils.formatEventDateForDisplay`, which correctly handles "Aujourd'hui", "Demain", and full localized dates, addressing the issue where "27 février 2026" was shown instead of "Aujourd'hui".
- The time display logic now checks for an `endsAt` time. If present, it displays the range "Start - End" (e.g., "14h00 - 16h00"). If `endsAt` is missing, it falls back to displaying just the start time, as before.

**Verification:**
- Verified that dates display relative terms correctly.
- Verified that time ranges are displayed when an end time is available.

---
*PR created automatically by Jules for task [8645386815928544086](https://jules.google.com/task/8645386815928544086) started by @clemPerrousset*