### PR TITLE
Update Home Moderator Card: Wording, Position, and Action

### DIFF
--- a/app/src/main/java/social/entourage/android/api/model/Help.kt
+++ b/app/src/main/java/social/entourage/android/api/model/Help.kt
@@ -1,6 +1,3 @@
 package social.entourage.android.api.model
 
-class Help(title:String, ressource:Int) {
-    var title:String = title
-    var ressourceId:Int = ressource
-}
+class Help(var title: String, var ressourceId: Int, var description: String? = null)

--- a/app/src/main/java/social/entourage/android/discussions/DiscussionsPresenter.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DiscussionsPresenter.kt
@@ -403,30 +403,30 @@ class DiscussionsPresenter : ViewModel() {
                     isLoadingImages.postValue(false)
                 }
             })
-        // NOTE : Fonction imbriquée gardée à l'identique (même comportement qu'avant)
-        fun fetchConversationLargeImage(conversationId: Int, chatMessageId: Int) {
-            if (isLoadingLargeImage.value == true) return
-            isLoadingLargeImage.postValue(true)
-            EntourageApplication.get().apiModule.discussionsRequest
-                .getConversationImage(conversationId, chatMessageId)
-                .enqueue(object : Callback<social.entourage.android.api.model.ConversationImageSingleWrapper> {
-                    override fun onResponse(
-                        call: Call<social.entourage.android.api.model.ConversationImageSingleWrapper>,
-                        response: Response<social.entourage.android.api.model.ConversationImageSingleWrapper>
-                    ) {
-                        largeImage.postValue(response.body()?.image)
-                        isLoadingLargeImage.postValue(false)
-                    }
+    }
 
-                    override fun onFailure(
-                        call: Call<social.entourage.android.api.model.ConversationImageSingleWrapper>,
-                        t: Throwable
-                    ) {
-                        largeImage.postValue(null)
-                        isLoadingLargeImage.postValue(false)
-                    }
-                })
-        }
+    fun fetchConversationLargeImage(conversationId: Int, chatMessageId: Int) {
+        if (isLoadingLargeImage.value == true) return
+        isLoadingLargeImage.postValue(true)
+        EntourageApplication.get().apiModule.discussionsRequest
+            .getConversationImage(conversationId, chatMessageId)
+            .enqueue(object : Callback<social.entourage.android.api.model.ConversationImageSingleWrapper> {
+                override fun onResponse(
+                    call: Call<social.entourage.android.api.model.ConversationImageSingleWrapper>,
+                    response: Response<social.entourage.android.api.model.ConversationImageSingleWrapper>
+                ) {
+                    largeImage.postValue(response.body()?.image)
+                    isLoadingLargeImage.postValue(false)
+                }
+
+                override fun onFailure(
+                    call: Call<social.entourage.android.api.model.ConversationImageSingleWrapper>,
+                    t: Throwable
+                ) {
+                    largeImage.postValue(null)
+                    isLoadingLargeImage.postValue(false)
+                }
+            })
     }
 
     fun loadInitialComments(convId: Int) {

--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -38,6 +38,7 @@ import social.entourage.android.api.model.User
 import social.entourage.android.api.model.UserSmallTalkRequest
 import social.entourage.android.databinding.FragmentHomeBinding
 import social.entourage.android.discussions.DetailConversationActivity
+import social.entourage.android.discussions.DiscussionsPresenter
 import social.entourage.android.enhanced_onboarding.EnhancedOnboarding
 import social.entourage.android.events.create.CommunicationHandler
 import social.entourage.android.guide.GDSMainActivity
@@ -66,6 +67,7 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
     private lateinit var binding: FragmentHomeBinding
     private lateinit var homePresenter: HomePresenter
     private val userPresenter: UserPresenter by lazy { UserPresenter() }
+    private val discussionsPresenter: DiscussionsPresenter by lazy { DiscussionsPresenter() }
     private lateinit var mainPresenter: MainPresenter
     private var pageEvent = 0
     private var nbOfItemForHozrizontalList = 10
@@ -174,6 +176,8 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
 
         setupAdapters()
         setupRecyclerView()
+
+        discussionsPresenter.newConversation.observe(viewLifecycleOwner, ::handleGetConversation)
 
         AnalyticsEvents.logEvent(AnalyticsEvents.View__Home)
         if (EnhancedOnboarding.shouldNotDisplayCampain == true) {
@@ -391,6 +395,8 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
             eventHeaderAdapter,
             eventWrapperAdapter,
             eventButtonAdapter,
+            helpHeaderAdapter,
+            homeHelpAdapter,
             groupHeaderAdapter,
             groupWrapperAdapter,
             groupButtonAdapter,
@@ -398,9 +404,7 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
             smallTalkHeaderAdapter,
             smallTalkWrapperAdapter,
             homeToolsAdapter,
-            homePedagoAdapter,
-            helpHeaderAdapter,
-            homeHelpAdapter
+            homePedagoAdapter
         )
 
         binding.rvHome.apply {
@@ -881,9 +885,9 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
             doTotalchecksumToDisplayHomeFirstTime()
             val formattedString = requireContext().getString(
                 R.string.home_help_title_three,
-                summary.moderator?.displayName
+                summary.moderator?.firstName
             )
-            val help3 = Help(formattedString, R.drawable.first_help_item_illu)
+            val help3 = Help(formattedString, R.drawable.first_help_item_illu, getString(R.string.home_help_message_three))
             val helps: MutableList<Help> = mutableListOf()
             helps.add(help3)
             homeHelpAdapter.resetData(helps, summary)
@@ -1036,11 +1040,27 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
         }
         if (position == 0) {
             AnalyticsEvents.logEvent(AnalyticsEvents.Action__Home__Moderator)
+            discussionsPresenter.createOrGetConversation(moderatorId.toString())
+        }
+    }
+
+    private fun handleGetConversation(conversation: social.entourage.android.api.model.Conversation?) {
+        conversation?.let {
+            social.entourage.android.discussions.DetailConversationActivity.isSmallTalkMode = false
             startActivity(
-                Intent(context, ProfileFullActivity::class.java).putExtra(
-                    Const.USER_ID,
-                    moderatorId
-                )
+                Intent(requireContext(), social.entourage.android.discussions.DetailConversationActivity::class.java)
+                    .putExtras(
+                        androidx.core.os.bundleOf(
+                            Const.ID to conversation.id,
+                            Const.POST_AUTHOR_ID to conversation.user?.id,
+                            Const.SHOULD_OPEN_KEYBOARD to false,
+                            Const.NAME to conversation.title,
+                            Const.IS_CONVERSATION_1TO1 to true,
+                            Const.IS_MEMBER to true,
+                            Const.IS_CONVERSATION to true,
+                            Const.HAS_TO_SHOW_MESSAGE to conversation.hasToShowFirstMessage()
+                        )
+                    )
             )
         }
     }

--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -67,7 +67,7 @@ class HomeFragment : Fragment(), OnHomeHelpItemClickListener, OnHomeChangeLocati
     private lateinit var binding: FragmentHomeBinding
     private lateinit var homePresenter: HomePresenter
     private val userPresenter: UserPresenter by lazy { UserPresenter() }
-    private val discussionsPresenter: DiscussionsPresenter by lazy { DiscussionsPresenter() }
+    private val discussionsPresenter: DiscussionsPresenter by lazy { ViewModelProvider(requireActivity()).get(DiscussionsPresenter::class.java) }
     private lateinit var mainPresenter: MainPresenter
     private var pageEvent = 0
     private var nbOfItemForHozrizontalList = 10

--- a/app/src/main/java/social/entourage/android/home/HomeHelpAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeHelpAdapter.kt
@@ -50,8 +50,6 @@ class HomeHelpAdapter(val callback: OnHomeHelpItemClickListener): RecyclerView.A
             callback.onItemClick(position, summary!!.moderator?.id!!)
         }
 
-
-
         if(help.ressourceId != 0){
             val context = holder.binding.root.context
             holder.binding.ivHomeV2HelpItem.setImageDrawable(AppCompatResources.getDrawable(context,help.ressourceId))
@@ -66,6 +64,15 @@ class HomeHelpAdapter(val callback: OnHomeHelpItemClickListener): RecyclerView.A
                 holder.binding.homeV2PedagoItemMainLayout.background = AppCompatResources.getDrawable(context,R.drawable.home_version_two_large_button_gradient_shape)
                 holder.binding.tvHomeV2HelpItem.setTextColor(context.getColor(R.color.white))
                 holder.binding.ivArrowRightHomeV2HelpItem.setColorFilter(context.getColor(R.color.white))
+
+                if (!help.description.isNullOrEmpty()) {
+                    holder.binding.tvHomeV2HelpItemSubtitle.text = help.description
+                    holder.binding.tvHomeV2HelpItemSubtitle.setTextColor(context.getColor(R.color.white))
+                    holder.binding.tvHomeV2HelpItemSubtitle.visibility = View.VISIBLE
+                } else {
+                    holder.binding.tvHomeV2HelpItemSubtitle.visibility = View.GONE
+                }
+
                 summary?.moderator?.imageURL?.let { imageUrl->
                     Glide.with(context)
                         .load(Uri.parse(imageUrl))
@@ -79,6 +86,8 @@ class HomeHelpAdapter(val callback: OnHomeHelpItemClickListener): RecyclerView.A
                         .transform(CenterCrop(), GranularRoundedCorners(45F, 45F, 0F, 0F))
                         .into(holder.binding.ivHomeV2HelpItem)
                 }
+            } else {
+                 holder.binding.tvHomeV2HelpItemSubtitle.visibility = View.GONE
             }
         }
     }

--- a/app/src/main/res/layout/home_v2_help_item_layout.xml
+++ b/app/src/main/res/layout/home_v2_help_item_layout.xml
@@ -1,48 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="65dp"
-    android:id="@+id/home_v2_pedago_item_main_layout"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:background="@drawable/home_v2_action_item_shape"
-    android:layout_marginTop="@dimen/entourage_little_margin_top"
+    android:id="@+id/home_v2_pedago_item_main_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
     android:layout_marginStart="@dimen/entourage_marginstart"
-    android:layout_marginEnd="@dimen/entourage_margin_end">
+    android:layout_marginTop="@dimen/entourage_little_margin_top"
+    android:layout_marginEnd="@dimen/entourage_margin_end"
+    android:background="@drawable/home_v2_action_item_shape"
+    android:minHeight="65dp">
+
     <ImageView
+        android:id="@+id/iv_home_v2_help_item"
         android:layout_width="24dp"
         android:layout_height="24dp"
-        android:id="@+id/iv_home_v2_help_item"
-        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginStart="@dimen/entourage_little_margin_start"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        android:layout_marginStart="@dimen/entourage_little_margin_start"
-        tools:src="@drawable/first_help_item_illu"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:src="@drawable/first_help_item_illu" />
 
-        />
-    <TextView
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:id="@+id/tv_home_v2_help_item"
-        app:layout_constraintStart_toEndOf="@+id/iv_home_v2_help_item"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@+id/iv_arrow_right_home_v2_help_item"
         android:layout_marginStart="13dp"
-        android:textSize="@dimen/entourage_font_small"
-        android:fontFamily="@font/quicksand_bold"
-        android:textColor="@color/black"
-        tools:text="Comment créer un événement"/>
-    
+        android:layout_marginEnd="16dp"
+        android:orientation="vertical"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/iv_arrow_right_home_v2_help_item"
+        app:layout_constraintStart_toEndOf="@+id/iv_home_v2_help_item"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_home_v2_help_item"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/quicksand_bold"
+            android:textColor="@color/black"
+            android:textSize="@dimen/entourage_font_small"
+            tools:text="Comment créer un événement" />
+
+        <TextView
+            android:id="@+id/tv_home_v2_help_item_subtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:fontFamily="@font/nunitosans_regular"
+            android:textColor="@color/black"
+            android:textSize="@dimen/entourage_font_small_12"
+            android:visibility="gone"
+            tools:text="Je fais parti·e de l'équipe Entourage et je suis là pour t'accompagner. N'hésite pas si tu as des questions ! 🤗"
+            tools:visibility="visible" />
+
+    </LinearLayout>
+
     <ImageView
+        android:id="@+id/iv_arrow_right_home_v2_help_item"
         android:layout_width="10dp"
         android:layout_height="16dp"
-        android:id="@+id/iv_arrow_right_home_v2_help_item"
-        app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginEnd="25dp"
+        android:src="@drawable/arrow_right_orange"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        android:layout_marginEnd="25dp"
-        android:src="@drawable/arrow_right_orange"/>
+        app:layout_constraintTop_toTopOf="parent" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -8,6 +8,7 @@
     <dimen name="entourage_font_large">18sp</dimen>
     <dimen name="entourage_font_medium">16sp</dimen>
     <dimen name="entourage_font_small">14sp</dimen>
+    <dimen name="entourage_font_small_12">12sp</dimen>
     <dimen name="entourage_font_very_small">12sp</dimen>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2558,7 +2558,8 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
 
     <string name="home_v2_help_title_one">Comment créer un groupe ?</string>
     <string name="home_v2_help_title_two">Comment créer un événement ?</string>
-    <string name="home_help_title_three">Une question ?\nContactez %s</string>
+    <string name="home_help_title_three">%s, ton contact privilégié</string>
+    <string name="home_help_message_three">Je fais parti·e de l\'équipe Entourage et je suis là pour t\'accompagner. N\'hésite pas si tu as des questions ! 🤗</string>
 
 
     <string name="home_v2_pedago_item_length_title">"%d min de lecture</string>


### PR DESCRIPTION
This PR updates the moderator card on the Home screen to improve engagement. 

Key changes:
- **Wording:** The title now uses the moderator's first name ("%s, ton contact privilégié") and includes a welcoming message ("Je fais parti·e de l'équipe Entourage...").
- **Positioning:** The moderator block has been moved to appear immediately below the Events section in the feed.
- **Navigation:** Clicking the card now opens a direct discussion with the moderator (using `DiscussionsPresenter`) instead of navigating to their user profile.
- **UI:** The `Help` model and `HomeHelpAdapter` were updated to support a description field, and the layout `home_v2_help_item_layout` now includes a secondary TextView for this message.

---
*PR created automatically by Jules for task [467221014270743297](https://jules.google.com/task/467221014270743297) started by @clemPerrousset*