### PR TITLE
feat: Update pedago tag colors to match mockup

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomeInitialPedagoAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeInitialPedagoAdapter.kt
@@ -10,10 +10,10 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.GranularRoundedCorners
 import social.entourage.android.R
-import social.entourage.android.api.model.Category
 import social.entourage.android.api.model.Pedago
 import social.entourage.android.databinding.HomeV2InitialPedagoItemLayoutBinding
 import social.entourage.android.home.pedago.OnItemClick
+import social.entourage.android.home.pedago.setPedagoCategory
 import social.entourage.android.tools.log.AnalyticsEvents
 
 class HomeInitialPedagoAdapter(private var onItemClickListener: OnItemClick): RecyclerView.Adapter<HomeInitialPedagoAdapter.PedagoViewHolder>() {
@@ -78,16 +78,7 @@ class HomeInitialPedagoAdapter(private var onItemClickListener: OnItemClick): Re
                 holder.binding.tvLenghtPedagoItem.visibility = View.VISIBLE
             }
         }
-        pedago.category.let {
-            val context = holder.binding.root.context
-            when(it){
-                Category.ALL -> holder.binding.tvTagPedagoItem.text = context.getString(R.string.home_v2_pedago_item_tag_all)
-                Category.ACT -> holder.binding.tvTagPedagoItem.text = context.getString(R.string.home_v2_pedago_item_tag_act)
-                Category.INSPIRE -> holder.binding.tvTagPedagoItem.text = context.getString(R.string.home_v2_pedago_item_tag_inspire)
-                Category.UNDERSTAND -> holder.binding.tvTagPedagoItem.text = context.getString(R.string.home_v2_pedago_item_tag_understand)
-                null -> holder.binding.tvTagPedagoItem.text = ""
-            }
-        }
+        holder.binding.tvTagPedagoItem.setPedagoCategory(pedago.category)
     }
 
     class PedagoViewHolder(val binding: HomeV2InitialPedagoItemLayoutBinding) : RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/java/social/entourage/android/home/HomePedagoAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomePedagoAdapter.kt
@@ -9,10 +9,10 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
 import com.bumptech.glide.load.resource.bitmap.GranularRoundedCorners
 import social.entourage.android.R
-import social.entourage.android.api.model.Category
 import social.entourage.android.api.model.Pedago
 import social.entourage.android.databinding.HomeV2PedagoItemLayoutBinding
 import social.entourage.android.home.pedago.OnItemClick
+import social.entourage.android.home.pedago.setPedagoCategory
 import social.entourage.android.tools.log.AnalyticsEvents
 
 class HomePedagoAdapter(private var onItemClickListener: OnItemClick): RecyclerView.Adapter<HomePedagoAdapter.PedagoViewHolder>() {
@@ -73,16 +73,7 @@ class HomePedagoAdapter(private var onItemClickListener: OnItemClick): RecyclerV
                 holder.binding.tvLenghtPedagoItem.visibility = View.VISIBLE
             }
         }
-        pedago.category.let {
-            val context = holder.binding.root.context
-            when(it){
-                Category.ALL -> holder.binding.tvTagPedagoItem.text = context.getString(R.string.home_v2_pedago_item_tag_all)
-                Category.ACT -> holder.binding.tvTagPedagoItem.text = context.getString(R.string.home_v2_pedago_item_tag_act)
-                Category.INSPIRE -> holder.binding.tvTagPedagoItem.text = context.getString(R.string.home_v2_pedago_item_tag_inspire)
-                Category.UNDERSTAND -> holder.binding.tvTagPedagoItem.text = context.getString(R.string.home_v2_pedago_item_tag_understand)
-                null -> holder.binding.tvTagPedagoItem.text = ""
-            }
-        }
+        holder.binding.tvTagPedagoItem.setPedagoCategory(pedago.category)
     }
 
     class PedagoViewHolder(val binding: HomeV2PedagoItemLayoutBinding) : RecyclerView.ViewHolder(binding.root)

--- a/app/src/main/java/social/entourage/android/home/pedago/PedagoTagHelper.kt
+++ b/app/src/main/java/social/entourage/android/home/pedago/PedagoTagHelper.kt
@@ -1,0 +1,42 @@
+package social.entourage.android.home.pedago
+
+import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.LayerDrawable
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import social.entourage.android.R
+import social.entourage.android.api.model.Category
+
+fun TextView.setPedagoCategory(category: Category?) {
+    val context = this.context
+    val backgroundDrawable = this.background as? LayerDrawable
+    val shapeDrawable = (backgroundDrawable?.findDrawableByLayerId(R.id.background_shape) as? GradientDrawable)?.mutate()
+
+    when (category) {
+        Category.ALL -> {
+            this.text = context.getString(R.string.home_v2_pedago_item_tag_all)
+            this.setTextColor(ContextCompat.getColor(context, R.color.light_orange))
+            (shapeDrawable as? GradientDrawable)?.setColor(ContextCompat.getColor(context, R.color.beige_clair))
+        }
+        Category.ACT -> {
+            this.text = context.getString(R.string.home_v2_pedago_item_tag_act)
+            this.setTextColor(ContextCompat.getColor(context, R.color.pedago_text_act))
+            (shapeDrawable as? GradientDrawable)?.setColor(ContextCompat.getColor(context, R.color.pedago_bg_act))
+        }
+        Category.INSPIRE -> {
+            this.text = context.getString(R.string.home_v2_pedago_item_tag_inspire)
+            this.setTextColor(ContextCompat.getColor(context, R.color.pedago_text_inspire))
+            (shapeDrawable as? GradientDrawable)?.setColor(ContextCompat.getColor(context, R.color.pedago_bg_inspire))
+        }
+        Category.UNDERSTAND -> {
+            this.text = context.getString(R.string.home_v2_pedago_item_tag_understand)
+            this.setTextColor(ContextCompat.getColor(context, R.color.pedago_text_understand))
+            (shapeDrawable as? GradientDrawable)?.setColor(ContextCompat.getColor(context, R.color.pedago_bg_understand))
+        }
+        null -> {
+            this.text = ""
+            this.setTextColor(ContextCompat.getColor(context, R.color.light_orange))
+            (shapeDrawable as? GradientDrawable)?.setColor(ContextCompat.getColor(context, R.color.beige_clair))
+        }
+    }
+}

--- a/app/src/main/res/drawable/home_v2_tv_tag_item_pedago_shape.xml
+++ b/app/src/main/res/drawable/home_v2_tv_tag_item_pedago_shape.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
+    <item android:id="@+id/background_shape">
         <shape
             android:shape="rectangle">
             <!-- Vous pouvez changer la couleur de fond ici -->

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -166,4 +166,12 @@
     <color name="grey_dark">#3d3d3d</color>
 
     <color name="bottom_bar_bg_color">@color/white</color>
+
+    <!-- Pedago categories -->
+    <color name="pedago_bg_act">@color/green_light</color>
+    <color name="pedago_text_act">@color/green</color>
+    <color name="pedago_bg_inspire">#FFF9E1</color>
+    <color name="pedago_text_inspire">#D9A300</color>
+    <color name="pedago_bg_understand">#E3F2FD</color>
+    <color name="pedago_text_understand">#0063BE</color>
 </resources>


### PR DESCRIPTION
This PR updates the visual style of pedagogical content tags in the Home feed to match the new design mockup.

**Changes:**
- Defined specific background and text colors for "Inspirer" (Yellow), "Agir" (Green), and "Comprendre" (Blue) in `colors.xml`.
- Modified the tag background drawable (`home_v2_tv_tag_item_pedago_shape.xml`) to include an ID for the shape layer, enabling dynamic color updates.
- Introduced a helper extension function `setPedagoCategory` in `PedagoTagHelper.kt` to handle the color logic safely (using `.mutate()` to prevent state sharing in RecyclerViews).
- Updated `HomePedagoAdapter` and `HomeInitialPedagoAdapter` to utilize this helper, ensuring consistent appearance across different list views.

---
*PR created automatically by Jules for task [2367043277946871002](https://jules.google.com/task/2367043277946871002) started by @clemPerrousset*