### PR TITLE
Add animations to HomeFragment lists

### DIFF
--- a/app/src/main/res/anim/item_animation_slide_from_right.xml
+++ b/app/src/main/res/anim/item_animation_slide_from_right.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="300">
+    <translate
+        android:fromXDelta="20%"
+        android:toXDelta="0"
+        android:interpolator="@android:anim/decelerate_interpolator" />
+    <alpha
+        android:fromAlpha="0.0"
+        android:toAlpha="1.0"
+        android:interpolator="@android:anim/decelerate_interpolator" />
+</set>

--- a/app/src/main/res/anim/layout_animation_slide_from_right.xml
+++ b/app/src/main/res/anim/layout_animation_slide_from_right.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layoutAnimation xmlns:android="http://schemas.android.com/apk/res/android"
+    android:delay="0.15"
+    android:animationOrder="normal"
+    android:animation="@anim/item_animation_slide_from_right" />

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -145,6 +145,7 @@
         android:scrollbars="vertical"
         android:background="@drawable/home_scrollview_shape"
         android:clipToPadding="false"
+        android:layoutAnimation="@anim/layout_animation_fall_down"
         />
 
     <FrameLayout

--- a/app/src/main/res/layout/home_horizontal_recycler_view.xml
+++ b/app/src/main/res/layout/home_horizontal_recycler_view.xml
@@ -5,4 +5,5 @@
     android:layout_height="wrap_content"
     android:orientation="horizontal"
     android:clipToPadding="false"
-    android:paddingStart="@dimen/entourage_marginstart" />
+    android:paddingStart="@dimen/entourage_marginstart"
+    android:layoutAnimation="@anim/layout_animation_slide_from_right" />


### PR DESCRIPTION
This change introduces fluid layout animations to the HomeFragment to improve the user experience as requested.

**Key Changes:**
1.  **Horizontal Lists (Events, Actions, Groups, etc.):**
    -   Modified `home_horizontal_recycler_view.xml` to use a new layout animation: `@anim/layout_animation_slide_from_right`.
    -   Created `app/src/main/res/anim/layout_animation_slide_from_right.xml` with a 0.15s delay.
    -   Created `app/src/main/res/anim/item_animation_slide_from_right.xml` which combines a translation (from 20% X to 0) and an alpha fade-in (0 to 1) over 300ms using a decelerate interpolator.

2.  **Vertical List (Main Home Scroll):**
    -   Modified `fragment_home.xml` to add `android:layoutAnimation="@anim/layout_animation_fall_down"` to the main `RecyclerView`.
    -   Verified that the referenced animation resources (`layout_animation_fall_down.xml` and `item_animation_fall_down.xml`) exist and are correctly configured.

These changes ensure that items within horizontal lists slide in one by one from the right, and the main sections fall down into place, creating a more dynamic and polished UI.

---
*PR created automatically by Jules for task [13407735838073479795](https://jules.google.com/task/13407735838073479795) started by @clemPerrousset*