### PR TITLE
Move reserved_female field to EventMetadata

### DIFF
--- a/app/src/main/java/social/entourage/android/api/model/Events.kt
+++ b/app/src/main/java/social/entourage/android/api/model/Events.kt
@@ -144,8 +144,6 @@ data class Events(
     @SerializedName("neighborhoods")
     var neighborhoods: MutableList<GroupEvent>? = mutableListOf(),
 
-    @SerializedName("reserved_female")
-    var reserved_female: Boolean? = null,
 ) : Serializable
 
 fun Events.toEventUi(context: Context): EventModel {
@@ -171,7 +169,6 @@ fun Events.toEventUi(context: Context): EventModel {
         this.distance,
         this.status,
         this.metadata?.previousAt,
-        this.reserved_female
     )
 }
 

--- a/app/src/main/java/social/entourage/android/api/model/MetaData.kt
+++ b/app/src/main/java/social/entourage/android/api/model/MetaData.kt
@@ -40,7 +40,10 @@ data class EventMetadata(
     val portraitUrl: String? = null,
 
     @field:SerializedName("landscape_url")
-    val landscapeUrl: String? = null
+    val landscapeUrl: String? = null,
+
+    @field:SerializedName("reserved_female")
+    val reserved_female: Boolean? = null,
 ) : Serializable
 
 data class ActionMetadata(

--- a/app/src/main/java/social/entourage/android/events/EventModel.kt
+++ b/app/src/main/java/social/entourage/android/events/EventModel.kt
@@ -45,7 +45,6 @@ class EventModel(
     val distance: Double? = null,
     val status: Status? = null,
     val previousAt: Date? = null,
-    var reserved_female: Boolean? = null,
 
     ) : Parcelable {
     constructor(parcel: Parcel) : this(
@@ -60,7 +59,6 @@ class EventModel(
         parcel.readByte() != 0.toByte(),
         parcel.readByte() != 0.toByte(),
     ) {
-        reserved_female = parcel.readValue(Boolean::class.java.classLoader) as? Boolean
     }
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
@@ -74,7 +72,6 @@ class EventModel(
         parcel.writeList(members)
         parcel.writeByte(if (member) 1 else 0)
         parcel.writeByte(if (admin) 1 else 0)
-        parcel.writeValue(reserved_female)
     }
 
     override fun describeContents(): Int {

--- a/app/src/main/java/social/entourage/android/events/create/CreateEvent.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEvent.kt
@@ -32,6 +32,9 @@ data class Metadata(
 
     @field:SerializedName("google_place_id")
     var googlePlaceId: String? = "",
+
+    @SerializedName("reserved_female")
+    var reserved_female: Boolean? = null,
 ) {
     fun endsAt(value: String) = apply {
         endsAt = value
@@ -50,7 +53,7 @@ data class Metadata(
     }
 
     override fun toString(): String {
-        return "EventMetadata(streetAddress=$streetAddress, startsAt=$startsAt, placeLimit=$placeLimit, displayAddress=$displayAddress, endsAt=$endsAt, googlePlaceId=$googlePlaceId)"
+        return "EventMetadata(streetAddress=$streetAddress, startsAt=$startsAt, placeLimit=$placeLimit, displayAddress=$displayAddress, endsAt=$endsAt, googlePlaceId=$googlePlaceId, reserved_female=$reserved_female)"
     }
 
 }
@@ -93,9 +96,6 @@ data class CreateEvent(
     var recurrence: Int? = null,
 
     var displayAddress: String? = null,
-
-    @SerializedName("reserved_female")
-    var reserved_female: Boolean? = null,
 
     ) {
     fun title(value: String) = apply {
@@ -143,7 +143,7 @@ data class CreateEvent(
     }
 
     override fun toString(): String {
-        return "CreateEvent(metadata=$metadata, description=$description, title=$title, eventUrl=$eventUrl, online=$online, latitude=$latitude, longitude=$longitude, otherInterest=$otherInterest, interests=$interests, entourageImageId=$entourageImageId, neighborhoodIds=$neighborhoodIds, recurrence=$recurrence, reserved_female=$reserved_female)"
+        return "CreateEvent(metadata=$metadata, description=$description, title=$title, eventUrl=$eventUrl, online=$online, latitude=$latitude, longitude=$longitude, otherInterest=$otherInterest, interests=$interests, entourageImageId=$entourageImageId, neighborhoodIds=$neighborhoodIds, recurrence=$recurrence)"
     }
 
 }

--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
@@ -91,7 +91,7 @@ class CreateEventStepTwoFragment : Fragment() {
 
     private fun setReservedFemale() {
         binding.layout.switchReservedFemale.setOnCheckedChangeListener { _, isChecked ->
-            CommunicationHandler.event.reserved_female = isChecked
+            CommunicationHandler.event.metadata?.reserved_female = isChecked
             binding.root.findViewById<View>(R.id.layout_reserved_female_info)?.visibility = if (isChecked) View.VISIBLE else View.GONE
         }
     }
@@ -203,9 +203,9 @@ class CreateEventStepTwoFragment : Fragment() {
                         it1
                     )
                 })
-                binding.layout.switchReservedFemale.isChecked = this.reserved_female ?: false
-                CommunicationHandler.event.reserved_female = this.reserved_female ?: false
-                binding.root.findViewById<View>(R.id.layout_reserved_female_info)?.visibility = if (this.reserved_female == true) View.VISIBLE else View.GONE
+                binding.layout.switchReservedFemale.isChecked = this.metadata?.reserved_female ?: false
+                CommunicationHandler.event.metadata?.reserved_female = this.metadata?.reserved_female ?: false
+                binding.root.findViewById<View>(R.id.layout_reserved_female_info)?.visibility = if (this.metadata?.reserved_female == true) View.VISIBLE else View.GONE
             }
         }
     }

--- a/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
@@ -280,7 +280,7 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
         with(binding) {
             eventName.text = event?.title
             eventNameToolbar.text = event?.title
-            if (event?.reserved_female == true) {
+            if (event?.metadata?.reserved_female == true) {
                 tvReservedFemale.visibility = View.VISIBLE
             } else {
                 tvReservedFemale.visibility = View.GONE

--- a/app/src/main/java/social/entourage/android/events/list/AllEventAdapter.kt
+++ b/app/src/main/java/social/entourage/android/events/list/AllEventAdapter.kt
@@ -97,7 +97,7 @@ class AllEventAdapter(var userId: Int?, var context: Context) :
                 holder.binding.ivEntourageLogo.visibility = View.GONE
             }
 
-            if (event.reserved_female == true) {
+            if (event.metadata?.reserved_female == true) {
                 holder.binding.ivWomanLogo.visibility = View.VISIBLE
             } else {
                 holder.binding.ivWomanLogo.visibility = View.GONE


### PR DESCRIPTION
Moves the `reserved_female` boolean field from the root of the event data models into the nested `metadata` objects. This structural update requires changes to both the API DTOs and UI models, as well as updating the event creation and display screens to reference the field via `metadata?.reserved_female`.

---
*PR created automatically by Jules for task [4166155987389982337](https://jules.google.com/task/4166155987389982337) started by @clemPerrousset*