### PR TITLE
Fix reserved female visibility and creation switch view

### DIFF
--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
@@ -92,7 +92,6 @@ class CreateEventStepTwoFragment : Fragment() {
     private fun setReservedFemale() {
         binding.layout.switchReservedFemale.setOnCheckedChangeListener { _, isChecked ->
             CommunicationHandler.event.metadata?.reserved_female = isChecked
-            CommunicationHandler.event.reserved_female = isChecked
         }
     }
 

--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
@@ -92,9 +92,7 @@ class CreateEventStepTwoFragment : Fragment() {
     private fun setReservedFemale() {
         binding.layout.switchReservedFemale.setOnCheckedChangeListener { _, isChecked ->
             CommunicationHandler.event.metadata?.reserved_female = isChecked
-            binding.root.findViewById<View>(R.id.layout_reserved_female_info)?.visibility = if (isChecked) View.VISIBLE else View.GONE
             CommunicationHandler.event.reserved_female = isChecked
-            //binding.root.findViewById<View>(R.id.layout_reserved_female_info)?.visibility = if (isChecked) View.VISIBLE else View.GONE
         }
     }
 

--- a/app/src/main/java/social/entourage/android/events/list/AllEventAdapter.kt
+++ b/app/src/main/java/social/entourage/android/events/list/AllEventAdapter.kt
@@ -87,20 +87,22 @@ class AllEventAdapter(var userId: Int?, var context: Context) :
             holder.binding.location.text = event.metadata?.displayAddress
             holder.binding.participants.text = event.membersCount.toString()
 
-            if (event.author?.communityRoles != null) {
-                if (event.author?.communityRoles?.contains("Équipe Entourage") == true || event.author.communityRoles?.contains("Animateur Entourage") == true) {
-                    holder.binding.ivEntourageLogo.visibility = View.VISIBLE
+            val isReservedFemale = event.metadata?.reserved_female == true
+
+            if (isReservedFemale) {
+                holder.binding.ivWomanLogo.visibility = View.VISIBLE
+                holder.binding.ivEntourageLogo.visibility = View.GONE
+            } else {
+                holder.binding.ivWomanLogo.visibility = View.GONE
+                if (event.author?.communityRoles != null) {
+                    if (event.author?.communityRoles?.contains("Équipe Entourage") == true || event.author.communityRoles?.contains("Animateur Entourage") == true) {
+                        holder.binding.ivEntourageLogo.visibility = View.VISIBLE
+                    } else {
+                        holder.binding.ivEntourageLogo.visibility = View.GONE
+                    }
                 } else {
                     holder.binding.ivEntourageLogo.visibility = View.GONE
                 }
-            } else {
-                holder.binding.ivEntourageLogo.visibility = View.GONE
-            }
-
-            if (event.metadata?.reserved_female == true) {
-                holder.binding.ivWomanLogo.visibility = View.VISIBLE
-            } else {
-                holder.binding.ivWomanLogo.visibility = View.GONE
             }
 
             if (event.member) {

--- a/app/src/main/java/social/entourage/android/home/HomeEventAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeEventAdapter.kt
@@ -136,8 +136,12 @@ class HomeEventAdapter(
                 ), 0
             )
         }
-        if (event.author?.communityRoles != null) {
+        if (event.metadata?.reserved_female == true) {
+            holder.binding.ivEntourageLogo.setImageResource(R.drawable.ic_entoutou_logo_woman)
+            holder.binding.ivEntourageLogo.visibility = View.VISIBLE
+        } else if (event.author?.communityRoles != null) {
             if (event.author?.communityRoles?.contains("Équipe Entourage") == true || event.author?.communityRoles?.contains("Animateur Entourage") == true) {
+                holder.binding.ivEntourageLogo.setImageResource(R.drawable.ic_entourage_little)
                 holder.binding.ivEntourageLogo.visibility = View.VISIBLE
             } else {
                 holder.binding.ivEntourageLogo.visibility = View.GONE


### PR DESCRIPTION
Make `ic_entoutou_logo_woman` completely replace `ic_entourage_logo` where `reserved_female` holds true, both on lists (AllEventAdapter) and Home Page (HomeEventAdapter). Also remouves the description layout below the "reservé aux femmes" switch.

---
*PR created automatically by Jules for task [2013686680763249133](https://jules.google.com/task/2013686680763249133) started by @clemPerrousset*