### PR TITLE
Fix home action card horizontal alignment

### DIFF
--- a/app/src/main/res/layout/home_v2_action_item_layout.xml
+++ b/app/src/main/res/layout/home_v2_action_item_layout.xml
@@ -5,7 +5,7 @@
     android:id="@+id/layout"
     android:layout_width="@dimen/home_action_card_width"
     android:layout_height="wrap_content"
-    android:layout_marginStart="@dimen/entourage_marginstart"
+    android:layout_marginStart="@dimen/entourage_little_margin_five"
     android:layout_marginTop="@dimen/entourage_little_margin_top"
     android:background="@drawable/home_v2_action_item_shape"
     android:padding="16dp">


### PR DESCRIPTION
Reduced `layout_marginStart` in `home_v2_action_item_layout.xml` from `16dp` (`entourage_marginstart`) to `4dp` (`entourage_little_margin_five`). This fixes the issue where the first action card in the home screen's horizontal list was pushed too far to the right relative to the section title, and makes the inter-item spacing consistent with event and group cards.

---
*PR created automatically by Jules for task [13375871358873121096](https://jules.google.com/task/13375871358873121096) started by @clemPerrousset*