### PR TITLE
Migrate Google Places SDK to 5.1.1 fields

### DIFF
--- a/app/src/main/java/social/entourage/android/events/EventFiltersActivity.kt
+++ b/app/src/main/java/social/entourage/android/events/EventFiltersActivity.kt
@@ -227,7 +227,7 @@ class EventFiltersActivity : AppCompatActivity() {
 
     //Google Place
     private fun onPlaceSearch() {
-        val fields = listOf(Place.Field.ID, Place.Field.NAME, Place.Field.LAT_LNG, Place.Field.ADDRESS)
+        val fields = listOf(Place.Field.ID, Place.Field.DISPLAY_NAME, Place.Field.LOCATION, Place.Field.FORMATTED_ADDRESS)
         val intent = Autocomplete.IntentBuilder(AutocompleteActivityMode.OVERLAY, fields)
             .build(this)
         resultLauncher.launch(intent)
@@ -239,19 +239,19 @@ class EventFiltersActivity : AppCompatActivity() {
         when (result.resultCode) {
             Activity.RESULT_OK -> {
                 val place = data?.let { Autocomplete.getPlaceFromIntent(it) }
-                if (place == null || place.address == null) return@registerForActivityResult
-                var addressStr = place.address.toString()
+                if (place == null || place.formattedAddress == null) return@registerForActivityResult
+                var addressStr = place.formattedAddress.toString()
                 val lastCommaIndex = addressStr.lastIndexOf(',')
                 if (lastCommaIndex > 0) {
                     addressStr = addressStr.substring(0, lastCommaIndex)
                 }
 
-                val address = Address(place.latLng!!.latitude, place.latLng!!.longitude, addressStr)
+                val address = Address(place.location!!.latitude, place.location!!.longitude, addressStr)
                 currentFilters?.modifyAddress(address)
                 currentFilters?.modifiyShortname(addressStr)
                 binding.placeName.text = addressStr
 
-                getCityNameFromPlace(place.latLng!!)
+                getCityNameFromPlace(place.location!!)
             }
             AutocompleteActivity.RESULT_ERROR -> {
                 clearFilterFromPlace()

--- a/app/src/main/java/social/entourage/android/main_filter/MainFilterActivity.kt
+++ b/app/src/main/java/social/entourage/android/main_filter/MainFilterActivity.kt
@@ -283,17 +283,17 @@ class MainFilterActivity : BaseActivity() {
     }
 
     private fun fetchPlaceDetails(placeId: String) {
-        val placeFields = listOf(Place.Field.ID, Place.Field.NAME, Place.Field.LAT_LNG, Place.Field.ADDRESS)
+        val placeFields = listOf(Place.Field.ID, Place.Field.DISPLAY_NAME, Place.Field.LOCATION, Place.Field.FORMATTED_ADDRESS)
         val request = FetchPlaceRequest.builder(placeId, placeFields).build()
 
         placesClient.fetchPlace(request).addOnSuccessListener { response ->
             val place = response.place
-            selectedLocation = place.name ?: ""
+            selectedLocation = place.displayName ?: ""
             binding.autoCompleteCityName.setText(selectedLocation)
             val autoCompleteTextView = binding.autoCompleteCityName as AutoCompleteTextView
             autoCompleteTextView.setSelection(autoCompleteTextView.text.length) // Placer le curseur à la fin
             autoCompleteTextView.dismissDropDown()
-            savedLocation = PlaceDetails(place.name!!, place.latLng!!.latitude, place.latLng!!.longitude)
+            savedLocation = PlaceDetails(place.displayName!!, place.location!!.latitude, place.location!!.longitude)
         }.addOnFailureListener { exception ->
             Log.e("PlaceAutocomplete", "Error: ${exception.message}", exception)
         }

--- a/app/src/main/java/social/entourage/android/onboarding/onboard/OnboardingZoneChoiceActivity.kt
+++ b/app/src/main/java/social/entourage/android/onboarding/onboard/OnboardingZoneChoiceActivity.kt
@@ -257,9 +257,9 @@ class OnboardingZoneChoiceActivity : AppCompatActivity(), OnMapReadyCallback {
     private fun fetchPlaceDetails(placeId: String) {
         val fields = listOf(
             Place.Field.ID,
-            Place.Field.NAME,
-            Place.Field.LAT_LNG,
-            Place.Field.ADDRESS,
+            Place.Field.DISPLAY_NAME,
+            Place.Field.LOCATION,
+            Place.Field.FORMATTED_ADDRESS,
             Place.Field.ADDRESS_COMPONENTS
         )
         val request = FetchPlaceRequest.builder(placeId, fields).build()
@@ -267,8 +267,8 @@ class OnboardingZoneChoiceActivity : AppCompatActivity(), OnMapReadyCallback {
         placesClient.fetchPlace(request)
             .addOnSuccessListener { rsp ->
                 val place = rsp.place
-                val latLng = place.latLng ?: return@addOnSuccessListener
-                val label = place.name ?: place.address ?: ""
+                val latLng = place.location ?: return@addOnSuccessListener
+                val label = place.displayName ?: place.formattedAddress ?: ""
                 lastPlaceId = place.id
                 lastDisplayAddress = label
 

--- a/app/src/main/java/social/entourage/android/profile/EditProfileActivity.kt
+++ b/app/src/main/java/social/entourage/android/profile/EditProfileActivity.kt
@@ -389,16 +389,16 @@ class EditProfileActivity : BaseActivity(), AvatarUploadView {
     }
 
     private fun fetchPlaceDetails(placeId: String) {
-        val placeFields = listOf(Place.Field.ID, Place.Field.NAME, Place.Field.LAT_LNG, Place.Field.ADDRESS)
+        val placeFields = listOf(Place.Field.ID, Place.Field.DISPLAY_NAME, Place.Field.LOCATION, Place.Field.FORMATTED_ADDRESS)
         val request = FetchPlaceRequest.builder(placeId, placeFields).build()
 
         placesClient.fetchPlace(request).addOnSuccessListener { response ->
             val place = response.place
-            binding.cityAction.setText(place.name ?: "", false)
+            binding.cityAction.setText(place.displayName ?: "", false)
 
-            savedLocation = place.latLng?.let {
+            savedLocation = place.location?.let {
                 PlaceDetails(
-                    place.name ?: "",
+                    place.displayName ?: "",
                     it.latitude,
                     it.longitude
                 )

--- a/app/src/main/java/social/entourage/android/user/edit/place/UserActionPlaceFragment.kt
+++ b/app/src/main/java/social/entourage/android/user/edit/place/UserActionPlaceFragment.kt
@@ -105,14 +105,14 @@ open class UserActionPlaceFragment : BaseDialogFragment() {
                 Activity.RESULT_OK -> {
                     if (this.activity == null) return
                     val place = intent?.let { Autocomplete.getPlaceFromIntent(it) }
-                    if (place == null || place.address == null) return
-                    var address = place.address.toString()
+                    if (place == null || place.formattedAddress == null) return
+                    var address = place.formattedAddress.toString()
                     val lastCommaIndex = address.lastIndexOf(',')
                     if (lastCommaIndex > 0) {
                         // remove the last part, which is the country
                         address = address.substring(0, lastCommaIndex)
                     }
-                    updateFromPlace(place.id, address, place.latLng)
+                    updateFromPlace(place.id, address, place.location)
                 }
                 AutocompleteActivity.RESULT_ERROR -> {
                     if (this.activity == null) return
@@ -224,7 +224,7 @@ open class UserActionPlaceFragment : BaseDialogFragment() {
     //**********//**********//**********
 
     open fun onSearchCalled() {
-        val fields = listOf(Place.Field.ID, Place.Field.NAME, Place.Field.LAT_LNG, Place.Field.ADDRESS)
+        val fields = listOf(Place.Field.ID, Place.Field.DISPLAY_NAME, Place.Field.LOCATION, Place.Field.FORMATTED_ADDRESS)
         val intent = Autocomplete.IntentBuilder(AutocompleteActivityMode.OVERLAY, fields)
             .build(requireActivity())
         startActivityForResult(intent, REQUEST_LOCATION_RETURN)


### PR DESCRIPTION
Updates the calls to Google Places SDK following a version upgrade to 5.1.1. In particular, it solves "Unresolved reference" errors by changing deprecated or removed `Place.Field` values and `place` properties to their updated V5 equivalents:
- `Place.Field.NAME` has been updated to `Place.Field.DISPLAY_NAME`.
- `Place.Field.LAT_LNG` has been updated to `Place.Field.LOCATION`.
- `Place.Field.ADDRESS` has been updated to `Place.Field.FORMATTED_ADDRESS`.
- `place.name` has been updated to `place.displayName`.
- `place.latLng` has been updated to `place.location`.
- `place.address` has been updated to `place.formattedAddress`.

All `latitude` and `longitude` fields are accessed directly on the new `location` property, which behaves exactly like the previous `latLng` property.

---
*PR created automatically by Jules for task [7462024471788387503](https://jules.google.com/task/7462024471788387503) started by @clemPerrousset*