### PR TITLE
Update event detail layout and actions

### DIFF
--- a/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
@@ -142,35 +142,7 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
 
 
     fun reduceButtonSizeImage(){
-        // Pour le bouton de partage
-        binding.bigBtnShare.post {
-            try {
-                val shareDrawable = ContextCompat.getDrawable(requireContext(), R.drawable.share_icon)
-                shareDrawable?.let {
-                    val sizeInPx = TypedValue.applyDimension(
-                        TypedValue.COMPLEX_UNIT_DIP, 14f, resources.displayMetrics
-                    ).toInt()
-                    it.setBounds(0, 0, sizeInPx, sizeInPx)
-                    binding.bigBtnShare.setCompoundDrawablesRelative(null, null, it, null)
-                }
-            } catch (e: IllegalStateException) {
-                Timber.e(e, "Error setting share icon")
-            }
-        }
-        binding.btnAddCalendar.post {
-            try {
-                ContextCompat.getDrawable(requireContext(), R.drawable.new_calendar)?.let {
-                    val sizeInPx = TypedValue.applyDimension(
-                        TypedValue.COMPLEX_UNIT_DIP, 14f, resources.displayMetrics
-                    ).toInt()
-                    it.setBounds(0, 0, sizeInPx, sizeInPx)
-                    binding.btnAddCalendar.setCompoundDrawablesRelative(null, null, it, null)
-                }
-            } catch (e: IllegalStateException) {
-                Timber.e(e, "Error setting calendar icon")
-            }
-        }
-
+        // Les anciens boutons ont été supprimés (bigBtnShare, btnAddCalendar)
     }
 
     override fun onPause() {
@@ -224,10 +196,10 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
         }
         if(event?.member == true) {
            binding.participateView.visibility = View.VISIBLE
-           binding.btnAddCalendar.visibility = View.VISIBLE
+           binding.discussionBox.visibility = View.VISIBLE
         }else{
             binding.participateView.visibility = View.GONE
-            binding.btnAddCalendar.visibility = View.GONE
+            binding.discussionBox.visibility = View.GONE
         }
         val latLng = LatLng(latitude, longitude)
         // Mise à jour de la carte
@@ -394,7 +366,11 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
             }
         }
         if(event?.member == true){
-            binding.buttonJoin.text = getString(R.string.see_conversation_event)
+            if (iAmOrganiser) {
+                binding.buttonJoin.text = getString(R.string.event_cancel_button)
+            } else {
+                binding.buttonJoin.text = getString(R.string.event_leave_button)
+            }
         }else{
             binding.buttonJoin.text = getString(R.string.share_and_join_event)
         }
@@ -525,7 +501,7 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
     }
 
     private fun handleAboutButton() {
-        binding.btnAddCalendar.setOnClickListener {
+        binding.dateStartsAt.root.setOnClickListener {
             AnalyticsEvents.logEvent(AnalyticsEvents.add_to_calendar_yes_clicked)
             shouldAddToAgenda = false
             val startMillis: Long = Calendar.getInstance().run {
@@ -552,7 +528,7 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
             requireContext().startActivity(intent)
         }
 
-        binding.bigBtnShare.setOnClickListener {
+        binding.iconShare.setOnClickListener {
             AnalyticsEvents.logEvent(AnalyticsEvents.EVENT_SHARED)
             val shareTitle = getString(R.string.share_title_event)
             val shareIntent = Intent(Intent.ACTION_SEND).apply {
@@ -560,6 +536,10 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
                 putExtra(Intent.EXTRA_TEXT, shareTitle + "\n" + event?.title + ": " + "\n" + createShareUrl())
             }
             startActivity(Intent.createChooser(shareIntent, getString(R.string.entourage_share_intent_title)))
+        }
+
+        binding.btnDiscussion.setOnClickListener {
+            goDiscussion()
         }
     }
 
@@ -639,12 +619,32 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
 
     private fun handleParticipateButton() {
         binding.buttonJoin.setOnClickListener {
+            if (event?.member == true) {
+                if (iAmOrganiser) {
+                    CustomAlertDialog.showWithCancelFirst(
+                        requireContext(),
+                        getString(R.string.delete_event_title),
+                        getString(R.string.delete_event_confirmation),
+                        getString(R.string.delete)
+                    ) {
+                        eventPresenter.cancelEvent(eventId)
+                    }
+                } else {
+                    CustomAlertDialog.showWithCancelFirst(
+                        requireContext(),
+                        getString(R.string.leave_event),
+                        getString(R.string.leave_event_dialog_content),
+                        getString(R.string.exit)
+                    ) {
+                        eventPresenter.leaveEvent(eventId)
+                    }
+                }
+                return@setOnClickListener
+            }
+
             requestInAppReview(requireContext())
             val meUser = EntourageApplication.me(activity)
             if(meUser?.roles?.contains("Ambassadeur") == true){
-                if(event?.member==true){
-                    goDiscussion()
-                }
                 CustomAlertDialog.showAmbassadorWithTwoButton(requireContext(),
                     onNo = {
                         if (event?.member==false){
@@ -659,8 +659,6 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
                 if (event?.member==false){
                     eventPresenter.participate(eventId)
                     binding.participateView.visibility = View.VISIBLE
-                }else{
-                    goDiscussion()
                 }
             }
         }

--- a/app/src/main/res/layout/fragment_feed_event.xml
+++ b/app/src/main/res/layout/fragment_feed_event.xml
@@ -65,6 +65,20 @@
                     tools:text="Dansons ensemble" />
 
                 <ImageView
+                    android:id="@+id/icon_share"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_marginEnd="8dp"
+                    android:background="@drawable/circle_white_plain"
+                    android:elevation="1dp"
+                    android:outlineAmbientShadowColor="@color/light_orange_opacity_35"
+                    android:outlineSpotShadowColor="@color/light_orange_opacity_35"
+                    android:padding="10dp"
+                    android:src="@drawable/share_icon"
+                    app:layout_constraintEnd_toStartOf="@id/icon_settings"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ImageView
                     android:id="@+id/icon_settings"
                     android:layout_width="40dp"
                     android:layout_height="40dp"
@@ -318,61 +332,57 @@
                                 android:visibility="gone"
                                 app:icon="@{@drawable/new_group_persons}" />
 
-                            <LinearLayout
-                                android:layout_width="wrap_content"
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:id="@+id/discussion_box"
+                                android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
-                                android:orientation="horizontal">
-                                <androidx.constraintlayout.widget.ConstraintLayout
-                                    android:layout_width="match_parent"
-                                    android:layout_height="wrap_content">
-                                    <TextView
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="0dp"
-                                        android:id="@+id/big_btn_share"
-                                        android:gravity="center"
-                                        android:paddingTop="8dp"
-                                        android:paddingBottom="8dp"
-                                        android:paddingStart="16dp"
-                                        android:paddingEnd="16dp"
-                                        android:layout_marginTop="20dp"
-                                        android:fontFamily="@font/quicksand_bold"
-                                        app:layout_constraintStart_toStartOf="parent"
-                                        app:layout_constraintTop_toTopOf="parent"
-                                        android:text="@string/event_btn_share_title"
-                                        android:textSize="15sp"
-                                        android:textColor="@color/black"
-                                        android:background="@drawable/shape_button_v9_negative"
-                                        android:drawablePadding="10dp"
-                                        app:drawableTint="@color/black"
-                                        app:drawableEndCompat="@drawable/share_icon" />
-                                </androidx.constraintlayout.widget.ConstraintLayout>
+                                android:layout_marginTop="20dp"
+                                android:background="@drawable/bg_info_bubble_beige"
+                                android:padding="16dp"
+                                android:visibility="gone"
+                                tools:visibility="visible">
 
-                                <androidx.constraintlayout.widget.ConstraintLayout
-                                    android:layout_width="match_parent"
+                                <ImageView
+                                    android:id="@+id/discussion_icon"
+                                    android:layout_width="44dp"
+                                    android:layout_height="44dp"
+                                    android:src="@drawable/new_message"
+                                    app:tint="@color/orange"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent"
+                                    app:layout_constraintBottom_toTopOf="@id/btn_discussion" />
+
+                                <TextView
+                                    android:id="@+id/discussion_text"
+                                    style="@style/left_courant_black"
+                                    android:layout_width="0dp"
                                     android:layout_height="wrap_content"
-                                    android:layout_marginStart="10dp">
-                                    <TextView
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="0dp"
-                                        android:id="@+id/btn_add_calendar"
-                                        android:gravity="center"
-                                        android:paddingTop="8dp"
-                                        android:paddingBottom="8dp"
-                                        android:paddingStart="16dp"
-                                        android:paddingEnd="16dp"
-                                        android:layout_marginTop="20dp"
-                                        android:fontFamily="@font/quicksand_bold"
-                                        app:layout_constraintStart_toStartOf="parent"
-                                        app:layout_constraintTop_toTopOf="parent"
-                                        android:textSize="15sp"
-                                        android:text="@string/add_to_agenda"
-                                        android:textColor="@color/black"
-                                        android:background="@drawable/shape_button_v9_negative"
-                                        android:drawablePadding="10dp"
-                                        app:drawableTint="@color/black"
-                                        app:drawableEndCompat="@drawable/new_calendar" />
-                                </androidx.constraintlayout.widget.ConstraintLayout>
-                            </LinearLayout>
+                                    android:layout_marginStart="16dp"
+                                    android:text="@string/event_discussion_title"
+                                    app:layout_constraintStart_toEndOf="@id/discussion_icon"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent"
+                                    app:layout_constraintBottom_toTopOf="@id/btn_discussion" />
+
+                                <Button
+                                    android:id="@+id/btn_discussion"
+                                    style="?android:attr/borderlessButtonStyle"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginTop="16dp"
+                                    android:background="@drawable/new_rounded_button_orange"
+                                    android:fontFamily="@font/quicksand_bold"
+                                    android:paddingHorizontal="24dp"
+                                    android:text="@string/event_discussion_button"
+                                    android:textAllCaps="false"
+                                    android:textColor="@color/white"
+                                    android:textSize="14sp"
+                                    android:minHeight="40dp"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintEnd_toEndOf="parent"
+                                    app:layout_constraintTop_toBottomOf="@id/discussion_text" />
+
+                            </androidx.constraintlayout.widget.ConstraintLayout>
 
                             <TextView
                                 android:id="@+id/event_description"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -851,6 +851,10 @@
     <string name="event_location_title">Locate your event</string>
     <string name="event_location_detail">The address will be added to the detailed description of your event.</string>
     <string name="event_btn_share_title">Share</string>
+    <string name="event_discussion_title">You can ask questions and discuss with the organizer and participants</string>
+    <string name="event_discussion_button">Event discussion</string>
+    <string name="event_cancel_button">Cancel event</string>
+    <string name="event_leave_button">Leave event</string>
     <string name="get_involved_title">Follow Entourage</string>
     <string name="get_involved_rate_us">Rate us in the Play Store</string>
     <string name="get_involved_facebook">Like our Facebook page</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1604,6 +1604,10 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="event_location_title">Localisez votre événement</string>
     <string name="event_location_detail">L’adresse sera ajoutée à la description détaillée de votre événement.</string>
     <string name="event_btn_share_title">Partager</string>
+    <string name="event_discussion_title">Vous pouvez poser vos questions et échanger avec l\'organisateur et les participants de l\'événement</string>
+    <string name="event_discussion_button">Discussion de l\'événement</string>
+    <string name="event_cancel_button">Annuler l\'événement</string>
+    <string name="event_leave_button">Quitter l\'événement</string>
 
     <!-- STRING GET INVOLVED -->
     <string name="get_involved_title">Suivre Entourage</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1803,6 +1803,10 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="event_location_title">Localisez votre événement</string>
     <string name="event_location_detail">L’adresse sera ajoutée à la description détaillée de votre événement.</string>
     <string name="event_btn_share_title">Partager</string>
+    <string name="event_discussion_title">Vous pouvez poser vos questions et échanger avec l\'organisateur et les participants de l\'événement</string>
+    <string name="event_discussion_button">Discussion de l\'événement</string>
+    <string name="event_cancel_button">Annuler l\'événement</string>
+    <string name="event_leave_button">Quitter l\'événement</string>
 
     <!-- STRING GET INVOLVED -->
     <string name="get_involved_title">Suivre Entourage</string>


### PR DESCRIPTION
Updates the Event Detail view (`EventFeedFragment`):
- Relocated the share action to a new top-right icon.
- Relocated the "Add to calendar" action to the event date text area.
- Added a new beige discussion box below the address, with an icon and "Discussion de l'événement" button. This box is only visible to event participants.
- The bottom sticky button is now strictly used for joining (if not member), leaving (if member), or canceling the event (if owner).
- Removed deprecated UI references to the old share and calendar buttons.

---
*PR created automatically by Jules for task [15960029420641978693](https://jules.google.com/task/15960029420641978693) started by @clemPerrousset*