### PR TITLE
Add Welcome Journey section to Home screen

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -26,6 +26,10 @@ import social.entourage.android.EntourageApplication
 import social.entourage.android.MainActivity
 import social.entourage.android.MainPresenter
 import social.entourage.android.R
+import android.net.Uri
+import android.widget.PopupWindow
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
 import social.entourage.android.actions.ActionsPresenter
 import social.entourage.android.api.model.Action
 import social.entourage.android.api.model.ActionSectionFilters
@@ -94,8 +98,14 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
     private var isRequestLoaded = false
     private var currentRequests: List<UserSmallTalkRequest> = emptyList()
 
+
     // Adapters
     private lateinit var concatAdapter: ConcatAdapter
+
+    // Welcome Journey
+    private lateinit var welcomeJourneyAdapter: HomeWelcomeJourneyAdapter
+    private var currentCompletedSteps = 0
+
 
     // Sensibilisation (Initial Pedago)
     private lateinit var initialPedagoHeaderAdapter: HomeSectionHeaderAdapter
@@ -157,6 +167,83 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
                 requireActivity().finish()
             }
         }
+    }
+
+
+    private fun updateWelcomeJourneyStep(stepIndex: Int) {
+        welcomeJourneyAdapter.updateStepState(stepIndex, true)
+        currentCompletedSteps++
+
+        if (currentCompletedSteps >= 3) {
+            welcomeJourneyAdapter.setFullyCompleted(true)
+            showCelebrationTooltip()
+        }
+    }
+
+    private fun showCelebrationTooltip() {
+        if (!isAdded) return
+        val inflater = LayoutInflater.from(requireContext())
+        val view = inflater.inflate(R.layout.layout_celebration_tooltip, null)
+        val popupWindow = PopupWindow(
+            view,
+            android.view.ViewGroup.LayoutParams.MATCH_PARENT,
+            android.view.ViewGroup.LayoutParams.WRAP_CONTENT,
+            true
+        )
+
+        binding.rvHome.postDelayed({
+             if (isAdded) {
+                popupWindow.showAtLocation(binding.rvHome, android.view.Gravity.TOP or android.view.Gravity.CENTER_HORIZONTAL, 0, 300)
+             }
+        }, 500)
+
+        binding.rvHome.postDelayed({
+            if (isAdded && popupWindow.isShowing) {
+                popupWindow.dismiss()
+            }
+        }, 4000)
+    }
+
+    private fun handleWelcomeJourneyClick(stepIndex: Int) {
+        when (stepIndex) {
+            1 -> showVideoModal()
+            2 -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.entourage.social/app/outings/webinar"))
+                startActivity(intent)
+                updateWelcomeJourneyStep(2)
+            }
+            3 -> {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.entourage.social/app/outings/papotages"))
+                startActivity(intent)
+                updateWelcomeJourneyStep(3)
+            }
+        }
+    }
+
+    private fun showVideoModal() {
+        if (!isAdded) return
+        val bottomSheetDialog = BottomSheetDialog(requireContext(), R.style.AppBottomSheetDialogTheme)
+        val view = layoutInflater.inflate(R.layout.dialog_welcome_video, null)
+        bottomSheetDialog.setContentView(view)
+
+        val btnContinue = view.findViewById<com.google.android.material.button.MaterialButton>(R.id.btn_continue)
+        val layoutVideo = view.findViewById<androidx.constraintlayout.widget.ConstraintLayout>(R.id.layout_video_placeholder)
+        val ivClose = view.findViewById<android.widget.ImageView>(R.id.iv_close)
+
+        ivClose?.setOnClickListener {
+            bottomSheetDialog.dismiss()
+        }
+
+        layoutVideo?.setOnClickListener {
+            btnContinue?.isEnabled = true
+        }
+
+        btnContinue?.setOnClickListener {
+            bottomSheetDialog.dismiss()
+            updateWelcomeJourneyStep(1)
+        }
+
+        bottomSheetDialog.show()
     }
 
     override fun onCreateView(
@@ -251,8 +338,15 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
         }
     }
 
+
     private fun setupAdapters() {
         val viewPool = RecyclerView.RecycledViewPool()
+
+        // 0. Welcome Journey
+        welcomeJourneyAdapter = HomeWelcomeJourneyAdapter(requireContext()) { stepIndex ->
+            handleWelcomeJourneyClick(stepIndex)
+        }
+
 
         // 1. Initial Pedago
         initialPedagoHeaderAdapter = HomeSectionHeaderAdapter()
@@ -401,9 +495,12 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
             .setIsolateViewTypes(true)
             .build()
 
+
         concatAdapter = ConcatAdapter(
             config,
+            welcomeJourneyAdapter,
             initialPedagoHeaderAdapter,
+
             initialPedagoWrapperAdapter,
             actionHeaderAdapter,
             actionWrapperAdapter, // MODIFIÉ : On utilise le Wrapper au lieu de l'adapter direct

--- a/app/src/main/java/social/entourage/android/home/HomeWelcomeJourneyAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeWelcomeJourneyAdapter.kt
@@ -1,0 +1,186 @@
+package social.entourage.android.home
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.button.MaterialButton
+import social.entourage.android.R
+import social.entourage.android.tools.utils.Const
+
+class HomeWelcomeJourneyAdapter(
+    private val context: Context,
+    private val onStepClick: (stepIndex: Int) -> Unit
+) : RecyclerView.Adapter<HomeWelcomeJourneyAdapter.ViewHolder>() {
+
+    private var step1Completed = false
+    private var step2Completed = false
+    private var step3Completed = false
+    private var isVisible = true
+    private var isCompletedFully = false
+
+    fun updateStepState(stepIndex: Int, isCompleted: Boolean) {
+        when (stepIndex) {
+            1 -> step1Completed = isCompleted
+            2 -> step2Completed = isCompleted
+            3 -> step3Completed = isCompleted
+        }
+        notifyItemChanged(0)
+    }
+
+    fun setVisible(visible: Boolean) {
+        isVisible = visible
+        notifyDataSetChanged()
+    }
+
+    fun setFullyCompleted(completed: Boolean) {
+        isCompletedFully = completed
+        notifyDataSetChanged()
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.home_welcome_journey, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind()
+    }
+
+    override fun getItemCount(): Int {
+        return if (isVisible) 1 else 0
+    }
+
+    inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        private val tvTitle: TextView = view.findViewById(R.id.tv_title)
+        private val tvStepCounter: TextView = view.findViewById(R.id.tv_step_counter)
+        private val progressBar: ProgressBar = view.findViewById(R.id.progress_bar)
+        private val tvMicrocopy: TextView = view.findViewById(R.id.tv_microcopy)
+
+        // Step 1
+        private val cardStep1: ConstraintLayout = view.findViewById(R.id.card_step_1)
+        private val tvBadgeStep1: TextView = view.findViewById(R.id.tv_badge_step_1)
+
+        // Step 2
+        private val cardStep2: ConstraintLayout = view.findViewById(R.id.card_step_2)
+        private val tvTitleStep2: TextView = view.findViewById(R.id.tv_title_step_2)
+        private val tvBadgeStep2: TextView = view.findViewById(R.id.tv_badge_step_2)
+        private val btnStep2: MaterialButton = view.findViewById(R.id.btn_step_2)
+
+        // Step 3
+        private val cardStep3: ConstraintLayout = view.findViewById(R.id.card_step_3)
+        private val tvTitleStep3: TextView = view.findViewById(R.id.tv_title_step_3)
+        private val tvBadgeStep3: TextView = view.findViewById(R.id.tv_badge_step_3)
+        private val btnStep3: MaterialButton = view.findViewById(R.id.btn_step_3)
+
+        // Success state
+        private val layoutSuccess: ConstraintLayout = view.findViewById(R.id.layout_success)
+
+        fun bind() {
+            var completedCount = 0
+            if (step1Completed) completedCount++
+            if (step2Completed) completedCount++
+            if (step3Completed) completedCount++
+
+            tvStepCounter.text = "$completedCount/3"
+            progressBar.progress = completedCount
+
+            // Microcopy
+            when (completedCount) {
+                0 -> tvMicrocopy.text = "Commençons 💛"
+                1 -> tvMicrocopy.text = "Vous êtes bien lancé(e) ✨"
+                2 -> tvMicrocopy.text = "Plus qu'une étape pour rejoindre la communauté 🎉"
+                else -> tvMicrocopy.text = "Parcours terminé !"
+            }
+
+            if (isCompletedFully) {
+                // Success message visible, steps hidden
+                layoutSuccess.visibility = View.VISIBLE
+                cardStep1.visibility = View.GONE
+                cardStep2.visibility = View.GONE
+                cardStep3.visibility = View.GONE
+                return
+            } else {
+                layoutSuccess.visibility = View.GONE
+                cardStep1.visibility = View.VISIBLE
+                cardStep2.visibility = View.VISIBLE
+                cardStep3.visibility = View.VISIBLE
+            }
+
+            // --- STEP 1 LOGIC ---
+            if (step1Completed) {
+                cardStep1.setBackgroundResource(R.drawable.bg_welcome_step_completed)
+                tvBadgeStep1.text = "Terminé"
+                tvBadgeStep1.setTextColor(ContextCompat.getColor(context, R.color.green))
+                tvBadgeStep1.setBackgroundResource(R.drawable.bg_badge_completed)
+            } else {
+                cardStep1.setBackgroundResource(R.drawable.bg_welcome_step_active)
+                tvBadgeStep1.text = "À faire"
+                tvBadgeStep1.setTextColor(ContextCompat.getColor(context, R.color.orange))
+                tvBadgeStep1.setBackgroundResource(R.drawable.bg_badge_todo)
+            }
+            cardStep1.setOnClickListener { onStepClick(1) }
+
+            // --- STEP 2 LOGIC ---
+            if (step2Completed) {
+                cardStep2.setBackgroundResource(R.drawable.bg_welcome_step_completed)
+                tvTitleStep2.setTextColor(ContextCompat.getColor(context, R.color.black))
+                tvBadgeStep2.visibility = View.VISIBLE
+                tvBadgeStep2.text = "Terminé"
+                tvBadgeStep2.setTextColor(ContextCompat.getColor(context, R.color.green))
+                tvBadgeStep2.setBackgroundResource(R.drawable.bg_badge_completed)
+                btnStep2.visibility = View.GONE
+                cardStep2.setOnClickListener(null)
+            } else if (step1Completed) { // Step 2 is active
+                cardStep2.setBackgroundResource(R.drawable.bg_welcome_step_active)
+                tvTitleStep2.setTextColor(ContextCompat.getColor(context, R.color.black))
+                tvBadgeStep2.visibility = View.VISIBLE
+                tvBadgeStep2.text = "À faire"
+                tvBadgeStep2.setTextColor(ContextCompat.getColor(context, R.color.orange))
+                tvBadgeStep2.setBackgroundResource(R.drawable.bg_badge_todo)
+                btnStep2.visibility = View.VISIBLE
+                btnStep2.setOnClickListener { onStepClick(2) }
+                cardStep2.setOnClickListener { onStepClick(2) }
+            } else { // Step 2 is future
+                cardStep2.setBackgroundResource(R.drawable.bg_welcome_step_future)
+                tvTitleStep2.setTextColor(ContextCompat.getColor(context, R.color.grey))
+                tvBadgeStep2.visibility = View.GONE
+                btnStep2.visibility = View.GONE
+                cardStep2.setOnClickListener(null)
+            }
+
+            // --- STEP 3 LOGIC ---
+            if (step3Completed) {
+                cardStep3.setBackgroundResource(R.drawable.bg_welcome_step_completed)
+                tvTitleStep3.setTextColor(ContextCompat.getColor(context, R.color.black))
+                tvBadgeStep3.visibility = View.VISIBLE
+                tvBadgeStep3.text = "Terminé"
+                tvBadgeStep3.setTextColor(ContextCompat.getColor(context, R.color.green))
+                tvBadgeStep3.setBackgroundResource(R.drawable.bg_badge_completed)
+                btnStep3.visibility = View.GONE
+                cardStep3.setOnClickListener(null)
+            } else if (step2Completed) { // Step 3 is active
+                cardStep3.setBackgroundResource(R.drawable.bg_welcome_step_active)
+                tvTitleStep3.setTextColor(ContextCompat.getColor(context, R.color.black))
+                tvBadgeStep3.visibility = View.VISIBLE
+                tvBadgeStep3.text = "À faire"
+                tvBadgeStep3.setTextColor(ContextCompat.getColor(context, R.color.orange))
+                tvBadgeStep3.setBackgroundResource(R.drawable.bg_badge_todo)
+                btnStep3.visibility = View.VISIBLE
+                btnStep3.setOnClickListener { onStepClick(3) }
+                cardStep3.setOnClickListener { onStepClick(3) }
+            } else { // Step 3 is future
+                cardStep3.setBackgroundResource(R.drawable.bg_welcome_step_future)
+                tvTitleStep3.setTextColor(ContextCompat.getColor(context, R.color.grey))
+                tvBadgeStep3.visibility = View.GONE
+                btnStep3.visibility = View.GONE
+                cardStep3.setOnClickListener(null)
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/bg_badge_completed.xml
+++ b/app/src/main/res/drawable/bg_badge_completed.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/green_light" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_badge_future.xml
+++ b/app/src/main/res/drawable/bg_badge_future.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white_f5_f5_f6" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_badge_todo.xml
+++ b/app/src/main/res/drawable/bg_badge_todo.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/orange_opacity_50" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_bottom_sheet_rounded.xml
+++ b/app/src/main/res/drawable/bg_bottom_sheet_rounded.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <corners
+        android:topLeftRadius="16dp"
+        android:topRightRadius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_placeholder_video.xml
+++ b/app/src/main/res/drawable/bg_placeholder_video.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/grey_dark" />
+    <corners android:radius="16dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_progress_bar_welcome.xml
+++ b/app/src/main/res/drawable/bg_progress_bar_welcome.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:id="@android:id/background">
+        <shape>
+            <corners android:radius="4dp" />
+            <solid android:color="@color/grey_middle" />
+        </shape>
+    </item>
+    <item android:id="@android:id/progress">
+        <clip>
+            <shape>
+                <corners android:radius="4dp" />
+                <solid android:color="@color/orange" />
+            </shape>
+        </clip>
+    </item>
+</layer-list>

--- a/app/src/main/res/drawable/bg_welcome_step_active.xml
+++ b/app/src/main/res/drawable/bg_welcome_step_active.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <stroke android:width="1dp" android:color="@color/orange_light_separator_event" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_welcome_step_completed.xml
+++ b/app/src/main/res/drawable/bg_welcome_step_completed.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/green_light" />
+    <stroke android:width="1dp" android:color="@color/green" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_welcome_step_future.xml
+++ b/app/src/main/res/drawable/bg_welcome_step_future.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <stroke android:width="1dp" android:color="@color/grey_onboarding_item_border" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/bg_welcome_success.xml
+++ b/app/src/main/res/drawable/bg_welcome_success.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/green_light" />
+    <corners android:radius="12dp" />
+</shape>

--- a/app/src/main/res/drawable/ic_bubble_grey.xml
+++ b/app/src/main/res/drawable/ic_bubble_grey.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#808080"
+        android:pathData="M20,2H4c-1.1,0 -2,0.9 -2,2v18l4,-4h14c1.1,0 2,-0.9 2,-2V4c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_laptop_grey.xml
+++ b/app/src/main/res/drawable/ic_laptop_grey.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#808080"
+        android:pathData="M20,18c1.1,0 1.99,-0.9 1.99,-2L22,6c0,-1.1 -0.9,-2 -2,-2H4c-1.1,0 -2,0.9 -2,2v10c0,1.1 0.9,2 2,2H0v2h24v-2h-4zM4,6h16v10H4V6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_play_circle_orange.xml
+++ b/app/src/main/res/drawable/ic_play_circle_orange.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF9C5D"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,16.5v-9l6,4.5 -6,4.5z"/>
+</vector>

--- a/app/src/main/res/layout/dialog_welcome_video.xml
+++ b/app/src/main/res/layout/dialog_welcome_video.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_bottom_sheet_rounded"
+    android:padding="24dp">
+
+    <ImageView
+        android:id="@+id/iv_close"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:padding="8dp"
+        android:src="@drawable/ic_close"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="@color/grey" />
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:fontFamily="@font/quicksand_bold"
+        android:gravity="center"
+        android:text="Découvrez l'esprit Entourage"
+        android:textColor="@color/black"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/iv_close" />
+
+    <!-- Video Placeholder -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_video_placeholder"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:layout_marginTop="24dp"
+        android:background="@drawable/bg_placeholder_video"
+        app:layout_constraintTop_toBottomOf="@+id/tv_title">
+
+        <ImageView
+            android:id="@+id/iv_play"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:src="@drawable/ic_play_circle_orange"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:fontFamily="@font/quicksand_bold"
+            android:text="Vidéo à venir"
+            android:textColor="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/iv_play" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <TextView
+        android:id="@+id/tv_description"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:fontFamily="@font/quicksand_regular"
+        android:text="Dans cette vidéo, vous allez découvrir comment nous créons du lien social et luttons contre l'isolement. Rejoignez une communauté bienveillante où chaque action compte.\n\nPrenez 2 minutes pour découvrir l'esprit Entourage."
+        android:textColor="@color/black"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/layout_video_placeholder" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_continue"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:enabled="false"
+        android:text="Continuer"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        app:backgroundTint="@color/orange"
+        app:cornerRadius="24dp"
+        app:layout_constraintTop_toBottomOf="@+id/tv_description" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/home_welcome_journey.xml
+++ b/app/src/main/res/layout/home_welcome_journey.xml
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="16dp"
+    android:layout_marginBottom="16dp"
+    android:layout_marginStart="@dimen/entourage_marginstart"
+    android:layout_marginEnd="@dimen/entourage_margin_end">
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/quicksand_bold"
+        android:text="Votre parcours de bienvenue"
+        android:textColor="@color/black"
+        android:textSize="20sp"
+        app:layout_constraintEnd_toStartOf="@+id/tv_step_counter"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_step_counter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/quicksand_bold"
+        android:text="0/3"
+        android:textColor="@color/orange"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="@+id/tv_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/tv_title" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="0dp"
+        android:layout_height="8dp"
+        android:layout_marginTop="12dp"
+        android:max="3"
+        android:progress="0"
+        android:progressDrawable="@drawable/bg_progress_bar_welcome"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/tv_title" />
+
+    <TextView
+        android:id="@+id/tv_microcopy"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:fontFamily="@font/quicksand_regular"
+        android:text="Commençons 💛"
+        android:textColor="@color/grey"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/progress_bar" />
+
+    <!-- Step 1: Video -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/card_step_1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/bg_welcome_step_active"
+        android:padding="16dp"
+        app:layout_constraintTop_toBottomOf="@+id/tv_microcopy">
+
+        <ImageView
+            android:id="@+id/iv_icon_step_1"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/ic_play_circle_orange"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_title_step_1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="8dp"
+            android:fontFamily="@font/quicksand_bold"
+            android:text="Commencer par la vidéo de bienvenue"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toStartOf="@+id/tv_badge_step_1"
+            app:layout_constraintStart_toEndOf="@+id/iv_icon_step_1"
+            app:layout_constraintTop_toTopOf="@+id/iv_icon_step_1" />
+
+        <TextView
+            android:id="@+id/tv_badge_step_1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_badge_todo"
+            android:fontFamily="@font/quicksand_medium"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="4dp"
+            android:text="À faire"
+            android:textColor="@color/orange"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_title_step_1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/tv_title_step_1" />
+
+        <TextView
+            android:id="@+id/tv_desc_step_1"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:fontFamily="@font/quicksand_regular"
+            android:text="Découvrez l'esprit d'Entourage et voyez comment agir concrètement contre l'isolement."
+            android:textColor="@color/grey"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/tv_title_step_1"
+            app:layout_constraintTop_toBottomOf="@+id/tv_title_step_1" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- Step 2: Webinar -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/card_step_2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/bg_welcome_step_future"
+        android:padding="16dp"
+        app:layout_constraintTop_toBottomOf="@+id/card_step_1">
+
+        <ImageView
+            android:id="@+id/iv_icon_step_2"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/ic_laptop_grey"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_title_step_2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="8dp"
+            android:fontFamily="@font/quicksand_bold"
+            android:text="S'inscrire au webinaire de prise en main"
+            android:textColor="@color/grey"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toStartOf="@+id/tv_badge_step_2"
+            app:layout_constraintStart_toEndOf="@+id/iv_icon_step_2"
+            app:layout_constraintTop_toTopOf="@+id/iv_icon_step_2" />
+
+        <TextView
+            android:id="@+id/tv_badge_step_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_badge_future"
+            android:fontFamily="@font/quicksand_medium"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="4dp"
+            android:text="À faire"
+            android:textColor="@color/grey"
+            android:textSize="12sp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_title_step_2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/tv_title_step_2" />
+
+        <TextView
+            android:id="@+id/tv_desc_step_2"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:fontFamily="@font/quicksand_regular"
+            android:text="Découvrez l'application en 45 min avec notre équipe et posez toutes vos questions."
+            android:textColor="@color/grey"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/tv_title_step_2"
+            app:layout_constraintTop_toBottomOf="@+id/tv_title_step_2" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_step_2"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="S'inscrire"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:visibility="gone"
+            app:backgroundTint="@color/orange"
+            app:cornerRadius="24dp"
+            app:layout_constraintTop_toBottomOf="@+id/tv_desc_step_2" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- Step 3: Papotages -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/card_step_3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:background="@drawable/bg_welcome_step_future"
+        android:padding="16dp"
+        app:layout_constraintTop_toBottomOf="@+id/card_step_2">
+
+        <ImageView
+            android:id="@+id/iv_icon_step_3"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/ic_bubble_grey"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_title_step_3"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="8dp"
+            android:fontFamily="@font/quicksand_bold"
+            android:text="Rejoindre une session de papotages"
+            android:textColor="@color/grey"
+            android:textSize="16sp"
+            app:layout_constraintEnd_toStartOf="@+id/tv_badge_step_3"
+            app:layout_constraintStart_toEndOf="@+id/iv_icon_step_3"
+            app:layout_constraintTop_toTopOf="@+id/iv_icon_step_3" />
+
+        <TextView
+            android:id="@+id/tv_badge_step_3"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/bg_badge_future"
+            android:fontFamily="@font/quicksand_medium"
+            android:paddingHorizontal="8dp"
+            android:paddingVertical="4dp"
+            android:text="À faire"
+            android:textColor="@color/grey"
+            android:textSize="12sp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@+id/tv_title_step_3"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/tv_title_step_3" />
+
+        <TextView
+            android:id="@+id/tv_desc_step_3"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:fontFamily="@font/quicksand_regular"
+            android:text="Chaque mardi à 18h, un moment convivial en visio pour discuter de tout et de rien avec d'autres membres."
+            android:textColor="@color/grey"
+            android:textSize="14sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/tv_title_step_3"
+            app:layout_constraintTop_toBottomOf="@+id/tv_title_step_3" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_step_3"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="Rejoindre"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            android:visibility="gone"
+            app:backgroundTint="@color/orange"
+            app:cornerRadius="24dp"
+            app:layout_constraintTop_toBottomOf="@+id/tv_desc_step_3" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- Success Message Container -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_success"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/bg_welcome_success"
+        android:padding="16dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@+id/tv_microcopy">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:fontFamily="@font/quicksand_bold"
+            android:gravity="center"
+            android:text="Intégration complète ! Tu fais maintenant partie de la communauté !"
+            android:textColor="@color/green"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_celebration_tooltip.xml
+++ b/app/src/main/res/layout/layout_celebration_tooltip.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="24dp"
+    android:background="@drawable/bg_bottom_sheet_rounded"
+    android:backgroundTint="@color/green_light"
+    android:elevation="8dp"
+    android:padding="16dp">
+
+    <ImageView
+        android:id="@+id/iv_star"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:src="@drawable/new_star_orange"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:fontFamily="@font/quicksand_bold"
+        android:text="Félicitations !"
+        android:textColor="@color/black"
+        android:textSize="18sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/iv_star"
+        app:layout_constraintTop_toTopOf="@+id/iv_star" />
+
+    <TextView
+        android:id="@+id/tv_desc"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:fontFamily="@font/quicksand_regular"
+        android:text="Votre parcours d'intégration est terminé. Vous avez désormais toutes les clés pour agir et créer du lien autour de vous."
+        android:textColor="@color/black"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/tv_title"
+        app:layout_constraintTop_toBottomOf="@+id/tv_title" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This commit addresses the User Story for the Welcome Journey implementation on the Home screen.

Included Features:
1. **Welcome Journey UI Block (`home_welcome_journey.xml`):**
   - Renders a top-level block inside the `HomeFragment`'s `ConcatAdapter` using a custom `HomeWelcomeJourneyAdapter`.
   - The UI includes a Title, "X/3" step counter, horizontal progress bar, and dynamic microcopy text which updates upon completion of each step.
   
2. **Steps Interaction:**
   - **Step 1 (Video Modal):** Opens a Bottom Sheet Dialog (`dialog_welcome_video.xml`). Clicking the video placeholder activates the "Continuer" button. Hitting continue closes the dialog and checks off Step 1.
   - **Step 2 & 3 (Webinar & Papotages):** Fires `ACTION_VIEW` deep-links for `https://www.entourage.social/app/outings/webinar` and `/papotages`. Hitting these options directly marks the steps complete.
   
3. **Completion States & Idempotency:**
   - Steps visually shift between "Future" (grey), "Active" (orange border), and "Completed" (green check/background).
   - Internal logic ensures that re-clicking completed steps doesn't artificially increment the progress counter.
   
4. **Celebration State (`layout_celebration_tooltip.xml`):**
   - After Step 3 is done, the 3 steps hide themselves and show an "Intégration complète" card view.
   - An auto-dismissing `PopupWindow` appears, anchored to the Top of the Recycler view with an orange star and a congratulations message.
   
The feature was built entirely offline with no backend storage dependency as specified in the issue.

---
*PR created automatically by Jules for task [750268719311952135](https://jules.google.com/task/750268719311952135) started by @clemPerrousset*