### PR TITLE
feat(events): Move reserved female toggle to step 3

### DIFF
--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepThreeFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepThreeFragment.kt
@@ -46,6 +46,13 @@ class CreateEventStepThreeFragment : Fragment() {
     private fun setViewMultiSelect() {
         setPlaceSelection()
         setLimitedPlacesSelection()
+        setReservedFemale()
+    }
+
+    private fun setReservedFemale() {
+        binding.layout.switchReservedFemale.setOnCheckedChangeListener { _, isChecked ->
+            CommunicationHandler.event.metadata?.reserved_female = isChecked
+        }
     }
 
     private fun adjustTextViewsForRTL(view: View) {
@@ -187,6 +194,9 @@ class CreateEventStepThreeFragment : Fragment() {
                     binding.layout.no.isChecked = true
                     binding.layout.eventLimitedPlaceCount.visibility = View.GONE
                 }
+
+                binding.layout.switchReservedFemale.isChecked = this.metadata?.reserved_female ?: false
+                CommunicationHandler.event.metadata?.reserved_female = this.metadata?.reserved_female ?: false
             }
         }
     }

--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepTwoFragment.kt
@@ -31,7 +31,6 @@ class CreateEventStepTwoFragment : Fragment() {
         setView()
         handleNextButtonState()
         setRecurrence()
-        setReservedFemale()
         adjustTextViewsForRTL(binding.layout.root)
         if (CommunicationHandler.eventEdited == null) {
             AnalyticsEvents.logEvent(AnalyticsEvents.Event_create_2)
@@ -86,12 +85,6 @@ class CreateEventStepTwoFragment : Fragment() {
                 R.id.every_two_week -> CommunicationHandler.event.recurrence =
                     Recurrence.EVERY_TWO_WEEKS.value
             }
-        }
-    }
-
-    private fun setReservedFemale() {
-        binding.layout.switchReservedFemale.setOnCheckedChangeListener { _, isChecked ->
-            CommunicationHandler.event.metadata?.reserved_female = isChecked
         }
     }
 
@@ -202,8 +195,6 @@ class CreateEventStepTwoFragment : Fragment() {
                         it1
                     )
                 })
-                binding.layout.switchReservedFemale.isChecked = this.metadata?.reserved_female ?: false
-                CommunicationHandler.event.metadata?.reserved_female = this.metadata?.reserved_female ?: false
             }
         }
     }

--- a/app/src/main/res/layout/layout_edit_event_step_three.xml
+++ b/app/src/main/res/layout/layout_edit_event_step_three.xml
@@ -157,6 +157,30 @@
                 android:text="@string/no" />
         </RadioGroup>
 
+        <LinearLayout
+            android:id="@+id/layout_reserved_female"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            app:layout_constraintTop_toBottomOf="@+id/event_limited_place">
+
+            <TextView
+                style="@style/left_courant_black"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/event_reserved_female_question" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/switch_reserved_female"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:thumbTint="@color/orange"
+                app:trackTint="@color/light_orange_opacity_50" />
+        </LinearLayout>
+
         <include
             android:id="@+id/event_limited_place_count_title"
             layout="@layout/layout_create_section_title_item"
@@ -164,7 +188,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="10dp"
             android:visibility="gone"
-            app:layout_constraintTop_toBottomOf="@id/event_limited_place"
+            app:layout_constraintTop_toBottomOf="@id/layout_reserved_female"
             app:mandatory="@{@string/mandatory}"
             app:title="@{@string/event_available_places}" />
 

--- a/app/src/main/res/layout/layout_edit_event_step_two.xml
+++ b/app/src/main/res/layout/layout_edit_event_step_two.xml
@@ -90,30 +90,6 @@
                 android:text="@string/every_two_week" />
         </RadioGroup>
 
-        <LinearLayout
-            android:id="@+id/layout_reserved_female"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            android:orientation="horizontal"
-            android:gravity="center_vertical"
-            app:layout_constraintTop_toBottomOf="@+id/recurrence">
-
-            <TextView
-                style="@style/left_courant_black"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/event_reserved_female_question" />
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/switch_reserved_female"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:thumbTint="@color/orange"
-                app:trackTint="@color/light_orange_opacity_50" />
-        </LinearLayout>
-
         <include
             android:id="@+id/error"
             layout="@layout/new_error"


### PR DESCRIPTION
The request was to move the "reserved for women" toggle from Step 2 (date and recurrence) to Step 3 (location and limited places) in the event creation flow.

The layout block `layout_reserved_female` was successfully migrated to `layout_edit_event_step_three.xml` underneath the "event with limited places" radio buttons (`event_limited_place`). Correspondingly, its associated view setup (`setReservedFemale()`) and instantiation logic within `setView()` reading from `CommunicationHandler.event.metadata` was shifted from `CreateEventStepTwoFragment.kt` to `CreateEventStepThreeFragment.kt`. Constraints and layouts were properly adapted for the UI flow.

---
*PR created automatically by Jules for task [1505295265936372224](https://jules.google.com/task/1505295265936372224) started by @clemPerrousset*