### PR TITLE
Fix recurring event cancellation in Event Settings and Event Details

### DIFF
--- a/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
+++ b/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
@@ -187,6 +187,12 @@ interface EventsRequest {
     @PUT("outings/{event_id}/batch_update")
     fun updateEventSiblings(
         @Path("event_id") eventId: Int,
+        @Body event: ArrayMap<String, Any>
+    ): Call<EventWrapper>
+
+    @PUT("outings/{event_id}/batch_update")
+    fun updateEventSiblings(
+        @Path("event_id") eventId: Int,
         @Body event: CreateEventWrapper
     ): Call<EventWrapper>
 

--- a/app/src/main/java/social/entourage/android/events/EventsPresenter.kt
+++ b/app/src/main/java/social/entourage/android/events/EventsPresenter.kt
@@ -206,6 +206,22 @@ class EventsPresenter : ViewModel() {
         })
     }
 
+    fun updateEventSiblings(eventId: Int, eventEdited: ArrayMap<String, Any>) {
+        EntourageApplication.get().apiModule.eventsRequest.updateEventSiblings(eventId, eventEdited)
+            .enqueue(object : Callback<EventWrapper> {
+                override fun onResponse(
+                    call: Call<EventWrapper>,
+                    response: Response<EventWrapper>
+                ) {
+                    isEventUpdated.value = response.isSuccessful && response.body()?.event != null
+                }
+
+                override fun onFailure(call: Call<EventWrapper>, t: Throwable) {
+                    isEventUpdated.value = false
+                }
+            })
+    }
+
     fun hasChangedFilter() {
         hasChangedFilter.postValue(false)
     }

--- a/app/src/main/java/social/entourage/android/events/details/SettingsModalFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/details/SettingsModalFragment.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.collection.ArrayMap
 import android.widget.Button
 import android.widget.ImageButton
 import android.widget.RadioButton
@@ -291,14 +292,16 @@ class SettingsModalFragment : BottomSheetDialogFragment() {
     }
 
     private fun cancelEventWithRecurrence() {
-//        event?.id?.let { id ->
-//            val editedEvent = hashMapOf<String, Any>(
-//                "status" to Status.CLOSED.value,
-//                "recurrency" to Recurrence.NO_RECURRENCE.value
-//            )
-//            val body = hashMapOf<String, Any>("outing" to editedEvent)
-//            eventPresenter.updateEvent(id, body)
-//        }
+        event?.id?.let { id ->
+            val editedEvent = ArrayMap<String, Any>().apply {
+                put("status", Status.CLOSED.value)
+                put("recurrency", Recurrence.NO_RECURRENCE.value)
+            }
+            val body = ArrayMap<String, Any>().apply {
+                put("outing", editedEvent)
+            }
+            eventPresenter.updateEventSiblings(id, body)
+        }
     }
 
     private fun showAlertDialogCancelEventWithRecurrence() {
@@ -322,7 +325,6 @@ class SettingsModalFragment : BottomSheetDialogFragment() {
         }
 
         btnYes.text = getString(R.string.cancel_event)
-        btnYes.setOnClickListener { dialog.dismiss() }
 
         custom.findViewById<ImageButton>(R.id.btn_cross).apply {
             visibility = View.VISIBLE

--- a/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/details/feed/EventFeedFragment.kt
@@ -12,6 +12,12 @@ import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.collection.ArrayMap
+import android.widget.Button
+import android.widget.ImageButton
+import android.widget.RadioButton
+import android.widget.RadioGroup
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
@@ -42,6 +48,7 @@ import social.entourage.android.api.MetaDataRepository
 import social.entourage.android.api.model.EntourageUser
 import social.entourage.android.api.model.Events
 import social.entourage.android.api.model.Post
+import social.entourage.android.events.create.Recurrence
 import social.entourage.android.api.model.Status
 import social.entourage.android.api.model.Survey
 import social.entourage.android.api.model.Tags
@@ -624,17 +631,75 @@ class EventFeedFragment : Fragment(), CallbackReportFragment, ReactionInterface,
         }
     }
 
+    private fun cancelEventWithoutRecurrence() {
+        eventPresenter.cancelEvent(eventId)
+    }
+
+    private fun cancelEventWithRecurrence() {
+        val editedEvent = ArrayMap<String, Any>().apply {
+            put("status", Status.CLOSED.value)
+            put("recurrency", Recurrence.NO_RECURRENCE.value)
+        }
+        val body = ArrayMap<String, Any>().apply {
+            put("outing", editedEvent)
+        }
+        eventPresenter.updateEventSiblings(eventId, body)
+    }
+
+    private fun showAlertDialogCancelEventWithRecurrence() {
+        val custom = LayoutInflater.from(requireContext())
+            .inflate(R.layout.layout_custom_alert_dialog_cancel_event, null)
+        val dialog = AlertDialog.Builder(requireContext()).setView(custom).create()
+
+        val btnYes = custom.findViewById<Button>(R.id.yes)
+        val radioGroup = custom.findViewById<RadioGroup>(R.id.recurrence)
+        val cancelOneEvent = custom.findViewById<RadioButton>(R.id.one_event)
+        val cancelAllEvents = custom.findViewById<RadioButton>(R.id.all_events_recurrent)
+
+        btnYes.isEnabled = false
+        btnYes.background = requireContext().getDrawable(R.drawable.btn_shape_light_orange)
+
+        radioGroup.setOnCheckedChangeListener { group, _ ->
+            btnYes.isEnabled = group.checkedRadioButtonId != -1
+            if (btnYes.isEnabled) {
+                btnYes.background = requireContext().getDrawable(R.drawable.btn_shape_orange_alert_dialog)
+            }
+        }
+
+        btnYes.text = getString(R.string.cancel_event)
+
+        custom.findViewById<ImageButton>(R.id.btn_cross).apply {
+            visibility = View.VISIBLE
+            setOnClickListener { dialog.dismiss() }
+        }
+
+        custom.findViewById<TextView>(R.id.title).text = getString(R.string.event_cancel_recurrent_event)
+
+        custom.findViewById<Button>(R.id.yes).setOnClickListener {
+            if (cancelOneEvent.isChecked) cancelEventWithoutRecurrence()
+            if (cancelAllEvents.isChecked) cancelEventWithRecurrence()
+            dialog.dismiss()
+        }
+
+        dialog.window?.setBackgroundDrawable(android.graphics.drawable.ColorDrawable(android.graphics.Color.TRANSPARENT))
+        dialog.show()
+    }
+
     private fun handleParticipateButton() {
         binding.buttonJoin.setOnClickListener {
             if (event?.member == true) {
                 if (iAmOrganiser) {
-                    CustomAlertDialog.showWithCancelFirst(
-                        requireContext(),
-                        getString(R.string.delete_event_title),
-                        getString(R.string.delete_event_confirmation),
-                        getString(R.string.delete)
-                    ) {
-                        eventPresenter.cancelEvent(eventId)
+                    if (event?.recurrence == null || event?.recurrence == Recurrence.NO_RECURRENCE.value) {
+                        CustomAlertDialog.showWithCancelFirst(
+                            requireContext(),
+                            getString(R.string.delete_event_title),
+                            getString(R.string.delete_event_confirmation),
+                            getString(R.string.delete)
+                        ) {
+                            cancelEventWithoutRecurrence()
+                        }
+                    } else {
+                        showAlertDialogCancelEventWithRecurrence()
                     }
                 } else {
                     CustomAlertDialog.showWithCancelFirst(


### PR DESCRIPTION
This PR restores the missing feature for organizers to cancel a recurring event series.

* **SettingsModalFragment:** Re-activated the commented-out `cancelEventWithRecurrence` logic, routing it properly to `updateEventSiblings` using an `ArrayMap` payload.
* **EventFeedFragment:** Enhanced the 'Cancel' button action (`handleParticipateButton`). If the event is recurring, it now prompts the user with the same alert dialog as the Settings modal, allowing them to choose between canceling just the single event or the whole series.
* **API Endpoints:** Added an overloaded `updateEventSiblings` method in `EventsPresenter` and `EventsRequest` that accepts an `ArrayMap<String, Any>` representing the batch update parameters (`status` and `recurrency`).
* **Fixes:** Explicitly imported and utilized `androidx.collection.ArrayMap` across all fragments to fix type mismatch compilation errors, and removed a redundant click listener assignment.

---
*PR created automatically by Jules for task [12319827556793024077](https://jules.google.com/task/12319827556793024077) started by @clemPerrousset*