### PR TITLE
Fix CustomAlertDialog.showWithCancelFirst usages

### DIFF
--- a/app/src/main/java/social/entourage/android/actions/create/CreateActionFragment.kt
+++ b/app/src/main/java/social/entourage/android/actions/create/CreateActionFragment.kt
@@ -261,7 +261,8 @@ class CreateActionFragment : Fragment() {
                 requireContext(),
                 getString(R.string.back_create_action_title),
                 getString(R.string.back_create_action_content,if (isDemand) getString(R.string.action_name_demand) else getString(R.string.action_name_contrib)),
-                getString(R.string.exit), {}
+                getString(R.string.exit),
+                onNo = {}
             ) {
                 requireActivity().finish()
             }

--- a/app/src/main/java/social/entourage/android/groups/create/CreateGroupFragment.kt
+++ b/app/src/main/java/social/entourage/android/groups/create/CreateGroupFragment.kt
@@ -158,7 +158,7 @@ class CreateGroupFragment : Fragment() {
                     getString(R.string.back_create_group_title),
                     getString(R.string.back_create_group_content),
                     getString(R.string.exit),
-                    {
+                    onNo = {
                         AnalyticsEvents.logEvent(
                             AnalyticsEvents.ACTION_NEW_GROUP_CANCEL_POP_CANCEL
                         )

--- a/app/src/main/java/social/entourage/android/report/ReportModalFragment.kt
+++ b/app/src/main/java/social/entourage/android/report/ReportModalFragment.kt
@@ -311,8 +311,8 @@ class ReportModalFragment : BottomSheetDialogFragment() {
                 CustomAlertDialog.showWithCancelFirst(
                     requireContext(),
                     title, message, btn,
-                    { /* cancel */ },
-                    {
+                    onNo = { /* cancel */ },
+                    onYes = {
                         AnalyticsEvents.logEvent(logEventTitleClick)
                         deleteMessage()
                         dismissCallback?.reloadView()
@@ -326,8 +326,8 @@ class ReportModalFragment : BottomSheetDialogFragment() {
                     getString(R.string.discussion_supress_the_post),
                     getString(R.string.discussion_ask_supress),
                     getString(R.string.discussion_button_supress),
-                    { /* cancel */ },
-                    {
+                    onNo = { /* cancel */ },
+                    onYes = {
                         AnalyticsEvents.logEvent(logEventTitleClick)
                         deleteMessage()
                         dismissCallback?.reloadView()

--- a/app/src/main/java/social/entourage/android/survey/CreateSurveyActivity.kt
+++ b/app/src/main/java/social/entourage/android/survey/CreateSurveyActivity.kt
@@ -150,10 +150,10 @@ class CreateSurveyActivity: BaseActivity() {
             getString(R.string.popup_survey_title),
             getString(R.string.popup_survey_content),
             getString(R.string.popup_survey_btn_leave),
-            {
+            onNo = {
 
             },
-            {
+            onYes = {
                 finish()
             })
     }


### PR DESCRIPTION
Fixes compilation failures caused by the update to `CustomAlertDialog.showWithCancelFirst` which added a new optional parameter, breaking usages that relied on positional parameters. Used named parameters to fix the mismatched types.

---
*PR created automatically by Jules for task [4502168180319647014](https://jules.google.com/task/4502168180319647014) started by @clemPerrousset*