### PR TITLE
Fix DiscussionMainFragment Jetpack Navigation crash

### DIFF
--- a/app/src/main/java/social/entourage/android/Navigation.kt
+++ b/app/src/main/java/social/entourage/android/Navigation.kt
@@ -65,9 +65,7 @@ object Navigation {
                         )
                 }
                 ActionSummary.INDEX -> {
-                    val bottomNavigationView =
-                        (context as Activity).findViewById<BottomNavigationView>(R.id.nav_view)
-                    bottomNavigationView.selectedItemId = R.id.navigation_messages
+                    fragmentManager.primaryNavigationFragment?.findNavController()?.navigate(R.id.navigation_messages)
                 }
                 ActionSummary.CREATE -> Utils.showToast(
                     context,
@@ -82,9 +80,7 @@ object Navigation {
                     )
                 ActionSummary.INDEX -> {
                     ViewPagerDefaultPageController.shouldSelectDiscoverGroups = true
-                    val bottomNavigationView =
-                        (context as Activity).findViewById<BottomNavigationView>(R.id.nav_view)
-                    bottomNavigationView.selectedItemId = R.id.navigation_groups
+                    fragmentManager.primaryNavigationFragment?.findNavController()?.navigate(R.id.navigation_groups)
                 }
                 ActionSummary.CREATE ->
                     return Intent(context, CreateGroupActivity::class.java)
@@ -139,11 +135,8 @@ object Navigation {
                             Const.IS_OUTING_DISCOVER,
                             NavArgument.Builder().setDefaultValue(true).build()
                         )
+                        it.navigate(R.id.navigation_events)
                     }
-
-                    val bottomNavigationView =
-                        (context as Activity).findViewById<BottomNavigationView>(R.id.nav_view)
-                    bottomNavigationView.selectedItemId = R.id.navigation_events
                 }
                 ActionSummary.CREATE ->
                     return Intent(context, CreateEventActivity::class.java)
@@ -161,9 +154,7 @@ object Navigation {
                         .putExtra(Const.IS_ACTION_MINE, false)
                 }
                 ActionSummary.INDEX -> {
-                    val bottomNavigationView =
-                        (context as Activity).findViewById<BottomNavigationView>(R.id.nav_view)
-                    bottomNavigationView.selectedItemId = R.id.navigation_donations
+                    fragmentManager.primaryNavigationFragment?.findNavController()?.navigate(R.id.navigation_donations)
                 }
                 ActionSummary.CREATE -> {
                     return Intent(context, CreateActionActivity::class.java)
@@ -184,11 +175,8 @@ object Navigation {
                             Const.IS_ACTION_DEMAND,
                             NavArgument.Builder().setDefaultValue(true).build()
                         )
+                        it.navigate(R.id.navigation_donations)
                     }
-
-                    val bottomNavigationView =
-                        (context as Activity).findViewById<BottomNavigationView>(R.id.nav_view)
-                    bottomNavigationView.selectedItemId = R.id.navigation_donations
                 }
                 ActionSummary.CREATE -> {
                     return Intent(context, CreateActionActivity::class.java)


### PR DESCRIPTION
Fixed an `IllegalArgumentException` originating from the Jetpack Navigation component (`The fragment DiscussionsMainFragment is unknown to the FragmentNavigator`) that crashed the application during `onPause` operations, particularly on Samsung devices with aggressive lifecycle handling.
The issue stemmed from programmatically overriding the `BottomNavigationView.selectedItemId` to navigate between main tabs within `Navigation.kt`, which bypasses safe `FragmentNavigator` state tracking when the view handles `setupWithNavController`. Refactored these occurrences to use `findNavController().navigate(R.id.navigation_*)` directly, enforcing a single source of truth for navigation state changes.

---
*PR created automatically by Jules for task [4027330787146877305](https://jules.google.com/task/4027330787146877305) started by @clemPerrousset*