### PR TITLE
feat: Add staff out-of-office banner

### DIFF
--- a/app/src/main/java/social/entourage/android/comment/CommentActivity.kt
+++ b/app/src/main/java/social/entourage/android/comment/CommentActivity.kt
@@ -60,7 +60,7 @@ protected var isOne2One = false
 protected var isConversation = false
 protected var isFromNotif = false
 var currentParentPost:Post? = null
-private val universalLinkManager = UniversalLinkManager(this)
+val universalLinkManager = UniversalLinkManager(this)
 var photoUri: Uri? = null
 private val eventPresenter: EventsPresenter by lazy { EventsPresenter() }
 private val discussionsPresenter: DiscussionsPresenter by lazy { DiscussionsPresenter() }

--- a/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
@@ -36,6 +36,7 @@ import social.entourage.android.api.model.Conversation
 import social.entourage.android.api.model.EntourageUser
 import social.entourage.android.api.model.Events
 import social.entourage.android.api.model.GroupMember
+import social.entourage.android.api.model.toUser
 import social.entourage.android.api.model.Post
 import social.entourage.android.api.model.SmallTalk
 import social.entourage.android.api.model.User
@@ -78,6 +79,9 @@ class DetailConversationActivity : CommentActivity() {
     private val discussionsPresenter: DiscussionsPresenter by lazy { DiscussionsPresenter() }
     private val smallTalkViewModel: SmallTalkViewModel by viewModels()
     private val groupPresenter: GroupPresenter by lazy { GroupPresenter() }
+
+    // State
+    private var hasClosedStaffBanner: Boolean = false
 
     // Launchers
     private lateinit var cameraLauncher: ActivityResultLauncher<Uri>
@@ -128,6 +132,12 @@ class DetailConversationActivity : CommentActivity() {
         discussionsPresenter.detailConversation.observe(this) { handleDetailConversation(it) }
         eventPresenter.getEvent.observe(this) { handleGetEvent(it) }
         eventPresenter.getMembersSearch.observe(this) { handleMembersSearch(it) }
+        groupPresenter.getGroup.observe(this) { group ->
+            group?.let {
+                val uri = Uri.parse("https://app.entourage.social/groups/${it.id}")
+                universalLinkManager.handleUniversalLink(uri)
+            }
+        }
         binding.comments.layoutManager = LinearLayoutManager(this)
         setupScrollPagination()
 
@@ -705,6 +715,119 @@ class DetailConversationActivity : CommentActivity() {
         // Mémoriser les membres pour les mentions
         allMembers = conversation.members ?: emptyList()
         Timber.d("[DetailConversation] allMembers.size=%s", allMembers.size)
+
+        // Banner Staff Out-of-Office check
+        checkStaffBannerDisplay(conversation)
+    }
+
+    private fun checkStaffBannerDisplay(conversation: Conversation) {
+        if (hasClosedStaffBanner) {
+            binding.layoutStaffBanner.visibility = View.GONE
+            return
+        }
+
+        // Must be a 1-to-1 conversation
+        if (!isOne2One || conversation.type == "outing") {
+            binding.layoutStaffBanner.visibility = View.GONE
+            return
+        }
+
+        // Find the other user
+        val meId = EntourageApplication.get().me()?.id
+        val otherUser = conversation.members?.firstOrNull { it.id != meId }
+
+        if (otherUser == null) {
+            binding.layoutStaffBanner.visibility = View.GONE
+            return
+        }
+
+        // Convert GroupMember to User to get roles
+        val otherUserRoles = conversation.user?.roles ?: otherUser.toUser().roles
+
+        val isStaff = otherUserRoles?.any { it.equals("Équipe Entourage", ignoreCase = true) } == true
+
+        if (!isStaff) {
+            binding.layoutStaffBanner.visibility = View.GONE
+            return
+        }
+
+        // Time Check
+        val calendar = java.util.Calendar.getInstance(java.util.TimeZone.getDefault())
+        val dayOfWeek = calendar.get(java.util.Calendar.DAY_OF_WEEK)
+        val hourOfDay = calendar.get(java.util.Calendar.HOUR_OF_DAY)
+        val minute = calendar.get(java.util.Calendar.MINUTE)
+
+        val isWeekend = (dayOfWeek == java.util.Calendar.FRIDAY && (hourOfDay > 18 || (hourOfDay == 18 && minute > 0))) ||
+                        dayOfWeek == java.util.Calendar.SATURDAY ||
+                        dayOfWeek == java.util.Calendar.SUNDAY ||
+                        (dayOfWeek == java.util.Calendar.MONDAY && (hourOfDay < 8 || (hourOfDay == 8 && minute < 59)))
+
+        val isNightTime = (hourOfDay > 18 || (hourOfDay == 18 && minute > 0)) ||
+                          (hourOfDay < 8 || (hourOfDay == 8 && minute < 59))
+
+        if (isWeekend || isNightTime) {
+            binding.layoutStaffBanner.visibility = View.VISIBLE
+            setupStaffBannerContent()
+        } else {
+            binding.layoutStaffBanner.visibility = View.GONE
+        }
+    }
+
+    private fun setupStaffBannerContent() {
+        // Handle links in the banner text
+        val staffMessage = getString(R.string.staff_out_of_office_banner)
+        val spannableStr = android.text.SpannableStringBuilder()
+
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            spannableStr.append(android.text.Html.fromHtml(staffMessage, android.text.Html.FROM_HTML_MODE_COMPACT))
+        } else {
+            @Suppress("DEPRECATION")
+            spannableStr.append(android.text.Html.fromHtml(staffMessage))
+        }
+
+        val spans = spannableStr.getSpans(0, spannableStr.length, android.text.style.URLSpan::class.java)
+        for (span in spans) {
+            val start = spannableStr.getSpanStart(span)
+            val end = spannableStr.getSpanEnd(span)
+            val flags = spannableStr.getSpanFlags(span)
+            val url = span.url
+
+            spannableStr.removeSpan(span)
+            val clickableSpan = object : android.text.style.ClickableSpan() {
+                override fun onClick(widget: View) {
+                    if (url.startsWith("tel:")) {
+                        val intent = Intent(Intent.ACTION_DIAL, Uri.parse(url))
+                        startActivity(intent)
+                    } else if (url == "entourage://groupe") {
+                        groupPresenter.getDefaultGroup()
+                    }
+                }
+
+                override fun updateDrawState(ds: android.text.TextPaint) {
+                    super.updateDrawState(ds)
+                    ds.color = ContextCompat.getColor(this@DetailConversationActivity, R.color.orange)
+                    ds.isUnderlineText = true
+                }
+            }
+            spannableStr.setSpan(clickableSpan, start, end, flags)
+        }
+
+        binding.tvStaffBannerMessage.text = spannableStr
+        binding.tvStaffBannerMessage.movementMethod = android.text.method.LinkMovementMethod.getInstance()
+
+        binding.btnCloseStaffBanner.setOnClickListener {
+            hasClosedStaffBanner = true
+            binding.layoutStaffBanner.animate()
+                .translationY(binding.layoutStaffBanner.height.toFloat())
+                .alpha(0f)
+                .setDuration(300)
+                .withEndAction {
+                    binding.layoutStaffBanner.visibility = View.GONE
+                    binding.layoutStaffBanner.translationY = 0f
+                    binding.layoutStaffBanner.alpha = 1f
+                }
+                .start()
+        }
     }
 
     private fun handleGetEvent(event: Events?) {

--- a/app/src/main/res/layout/activity_comments.xml
+++ b/app/src/main/res/layout/activity_comments.xml
@@ -339,13 +339,61 @@
         </LinearLayout>
 
         <!-- 6) Container pour les suggestions (mentions), au-dessus du bloc post_comment -->
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_staff_banner"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/white"
+            android:paddingStart="16dp"
+            android:paddingTop="12dp"
+            android:paddingBottom="12dp"
+            android:paddingEnd="8dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@+id/post_comment"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent">
+
+            <TextView
+                android:id="@+id/tv_staff_banner_message"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                style="@style/left_courant_black"
+                android:textSize="13sp"
+                android:lineSpacingExtra="4dp"
+                android:layout_marginEnd="8dp"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/btn_close_staff_banner"
+                tools:text="@string/staff_out_of_office_banner" />
+
+            <ImageView
+                android:id="@+id/btn_close_staff_banner"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:padding="10dp"
+                android:src="@drawable/icon_cross"
+                app:tint="@color/grey_onboarding_item_border"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/beige_clair"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toStartOf="parent"/>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
         <FrameLayout
             android:id="@+id/mentionSuggestionsContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:visibility="gone"
             android:background="@color/beige_clair"
-            app:layout_constraintBottom_toTopOf="@+id/post_comment"
+            app:layout_constraintBottom_toTopOf="@+id/layout_staff_banner"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent">
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -267,6 +267,7 @@
     <string name="leave_group_dialog_content">هل تريد مغادرة المجموعة؟</string>
     <string name="discuss">يعلق…</string>
     <string name="discussbis">لكتابة رسالة…</string>
+    <string name="staff_out_of_office_banner">الفريق في استراحة... 🌙 في حالة الطوارئ: &lt;a href="tel:15"&gt;15&lt;/a&gt;، &lt;a href="tel:18"&gt;18&lt;/a&gt; أو &lt;a href="tel:115"&gt;115&lt;/a&gt;. للحصول على مساعدة فورية، جيرانك موجودون في &lt;a href="entourage://groupe"&gt;المجموعة&lt;/a&gt;! 🏠 سنرد عليك قريبًا.</string>
     <string name="no_comments">بدون تعليق</string>
     <string name="comments_title">تعليقات</string>
     <string name="write_your_message">اكتب رسالتك</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -278,6 +278,7 @@ Sie werden diese Nachricht lesen, sobald sie der Gruppe beitreten.</string>
     <string name="leave_group_dialog_content">Möchten Sie die Gruppe verlassen?</string>
     <string name="discuss">Kommentar…</string>
     <string name="discussbis">Um eine Nachricht zu schreiben…</string>
+    <string name="staff_out_of_office_banner">Das Team macht Pause... 🌙 Im Notfall: &lt;a href="tel:15"&gt;15&lt;/a&gt;, &lt;a href="tel:18"&gt;18&lt;/a&gt; oder &lt;a href="tel:115"&gt;115&lt;/a&gt;. Für sofortige Hilfe sind deine Nachbarn in der &lt;a href="entourage://groupe"&gt;Gruppe&lt;/a&gt;! 🏠 Wir antworten bald.</string>
     <string name="no_comments">Keine Kommentare</string>
     <string name="comments_title">Kommentare</string>
     <string name="write_your_message">Schreibe deine Nachricht</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -253,6 +253,7 @@
     <string name="leave_group_dialog_content">Do you want to leave the group?</string>
     <string name="discuss">Comment…</string>
     <string name="discussbis">Write a message…</string>
+    <string name="staff_out_of_office_banner">The team is on a break... 🌙 In case of emergency: &lt;a href="tel:15"&gt;15&lt;/a&gt;, &lt;a href="tel:18"&gt;18&lt;/a&gt; or &lt;a href="tel:115"&gt;115&lt;/a&gt;. For immediate help, your neighbors are on the &lt;a href="entourage://groupe"&gt;group&lt;/a&gt;! 🏠 We\'ll answer you soon.</string>
     <string name="no_comments">No comments</string>
     <string name="comments_title">Comments</string>
     <string name="write_your_message">Write your message</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -280,6 +280,7 @@ Leerán este mensaje tan pronto como se unan al grupo.</string>
     <string name="leave_group_dialog_content">¿Quieres dejar el grupo?</string>
     <string name="discuss">Comentario…</string>
     <string name="discussbis">Para escribir un mensaje…</string>
+    <string name="staff_out_of_office_banner">El equipo está en pausa... 🌙 En caso de emergencia: &lt;a href="tel:15"&gt;15&lt;/a&gt;, &lt;a href="tel:18"&gt;18&lt;/a&gt; o &lt;a href="tel:115"&gt;115&lt;/a&gt;. Para ayuda inmediata, ¡tus vecinos están en el &lt;a href="entourage://groupe"&gt;grupo&lt;/a&gt;! 🏠 Te responderemos pronto.</string>
     <string name="no_comments">Sin comentarios</string>
     <string name="write_your_message">escribe tu mensaje</string>
     <string name="share_post">Compartir, repartir</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -280,6 +280,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="leave_group_dialog_content">Souhaitez-vous quitter le groupe ?</string>
     <string name="discuss">Commenter…</string>
     <string name="discussbis">Écrire un message…</string>
+    <string name="staff_out_of_office_banner">L’équipe est en pause... 🌙 En cas d\'urgence : &lt;a href="tel:15"&gt;15&lt;/a&gt;, &lt;a href="tel:18"&gt;18&lt;/a&gt; ou &lt;a href="tel:115"&gt;115&lt;/a&gt;. Pour une aide immédiate, vos voisins sont sur le &lt;a href="entourage://groupe"&gt;groupe&lt;/a&gt; ! 🏠 On vous répond vite.</string>
     <string name="no_comments">Pas de messages</string>
     <string name="event_date">"dd/MM/yyyy"</string>
     <string name="event_date_time">"dd MMMM yyyy à HH'h'mm"</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -280,6 +280,7 @@ Przeczytają tę wiadomość, gdy tylko dołączą do grupy.</string>
     <string name="leave_group_dialog_content">Czy chcesz opuścić grupę?</string>
     <string name="discuss">Komentarz…</string>
     <string name="discussbis">Aby napisać wiadomość…</string>
+    <string name="staff_out_of_office_banner">Zespół ma przerwę... 🌙 W nagłych wypadkach: &lt;a href="tel:15"&gt;15&lt;/a&gt;, &lt;a href="tel:18"&gt;18&lt;/a&gt; lub &lt;a href="tel:115"&gt;115&lt;/a&gt;. Aby uzyskać natychmiastową pomoc, twoi sąsiedzi są w &lt;a href="entourage://groupe"&gt;grupie&lt;/a&gt;! 🏠 Odpowiemy wkrótce.</string>
     <string name="no_comments">Bez komentarza</string>
     <string name="comments_title">Uwagi</string>
     <string name="write_your_message">Napisz swoją wiadomość</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -280,6 +280,7 @@ Ei vor citi acest mesaj imediat ce se vor alătura grupului.</string>
     <string name="leave_group_dialog_content">Vrei să părăsești grupul?</string>
     <string name="discuss">Cometariu…</string>
     <string name="discussbis">Pentru a scrie un mesaj...</string>
+    <string name="staff_out_of_office_banner">Echipa este în pauză... 🌙 În caz de urgență: &lt;a href="tel:15"&gt;15&lt;/a&gt;, &lt;a href="tel:18"&gt;18&lt;/a&gt; sau &lt;a href="tel:115"&gt;115&lt;/a&gt;. Pentru ajutor imediat, vecinii tăi sunt în &lt;a href="entourage://groupe"&gt;grup&lt;/a&gt;! 🏠 Vă vom răspunde în curând.</string>
     <string name="no_comments">Fara comentarii</string>
     <string name="comments_title">Comentarii</string>
     <string name="write_your_message">Scrie-ți mesajul</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -280,6 +280,7 @@
     <string name="leave_group_dialog_content">Ви хочете залишити групу?</string>
     <string name="discuss">Коментувати…</string>
     <string name="discussbis">Щоб написати повідомлення…</string>
+    <string name="staff_out_of_office_banner">Команда на перерві... 🌙 У разі надзвичайної ситуації: &lt;a href="tel:15"&gt;15&lt;/a&gt;, &lt;a href="tel:18"&gt;18&lt;/a&gt; або &lt;a href="tel:115"&gt;115&lt;/a&gt;. Для негайної допомоги ваші сусіди в &lt;a href="entourage://groupe"&gt;групі&lt;/a&gt;! 🏠 Ми відповімо незабаром.</string>
     <string name="no_comments">Без коментарів</string>
     <string name="comments_title">Коментарі</string>
     <string name="write_your_message">Напишіть своє повідомлення</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,6 +288,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="leave_group_dialog_content">Souhaitez-vous quitter le groupe ?</string>
     <string name="discuss">Commenter…</string>
     <string name="discussbis">Écrire un message…</string>
+    <string name="staff_out_of_office_banner">L’équipe est en pause... 🌙 En cas d\'urgence : &lt;a href="tel:15"&gt;15&lt;/a&gt;, &lt;a href="tel:18"&gt;18&lt;/a&gt; ou &lt;a href="tel:115"&gt;115&lt;/a&gt;. Pour une aide immédiate, vos voisins sont sur le &lt;a href="entourage://groupe"&gt;groupe&lt;/a&gt; ! 🏠 On vous répond vite.</string>
     <string name="no_comments">Pas de messages</string>
     <string name="event_date">"dd/MM/yyyy"</string>
     <string name="event_date_time">"dd MMMM yyyy à HH'h'mm"</string>


### PR DESCRIPTION
Implement a contextual out-of-office banner in ConversationDetail views when messaging staff outside of working hours, featuring clickable emergency links and group redirection.

---
*PR created automatically by Jules for task [10013243510090752273](https://jules.google.com/task/10013243510090752273) started by @clemPerrousset*