### PR TITLE
feature(Home): connect welcome journey state to Summary events

### DIFF
--- a/app/src/main/java/social/entourage/android/api/model/Summary.kt
+++ b/app/src/main/java/social/entourage/android/api/model/Summary.kt
@@ -58,6 +58,9 @@ class Summary : Serializable {
     @SerializedName("preference")
     var preference: String? = null
 
+    @SerializedName("events")
+    var events: MutableList<String>? = null
+
 }
 
 class HomeAction : Serializable {

--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -171,6 +171,9 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
 
 
     private fun updateWelcomeJourneyStep(stepIndex: Int) {
+        // Prevent incrementing if already complete (e.g. from backend state)
+        if (stepIndex <= currentCompletedSteps) return
+
         welcomeJourneyAdapter.updateStepState(stepIndex, true)
         currentCompletedSteps++
 
@@ -202,6 +205,34 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
                 popupWindow.dismiss()
             }
         }, 4000)
+    }
+
+    private fun handleWelcomeJourneyState(events: List<String>?) {
+        if (!::welcomeJourneyAdapter.isInitialized) return
+
+        val hasWatchedVideo = events?.contains("onboarding.resource.welcome_watched") == true
+        val hasJoinedWebinar = events?.contains("onboarding.outing.webinar_or_first_steps") == true
+        val hasJoinedPapotages = events?.contains("onboarding.outing.papotages") == true
+
+        var completedCount = 0
+        if (hasWatchedVideo) {
+            welcomeJourneyAdapter.updateStepState(1, true)
+            completedCount++
+        }
+        if (hasJoinedWebinar) {
+            welcomeJourneyAdapter.updateStepState(2, true)
+            completedCount++
+        }
+        if (hasJoinedPapotages) {
+            welcomeJourneyAdapter.updateStepState(3, true)
+            completedCount++
+        }
+
+        currentCompletedSteps = completedCount
+
+        if (currentCompletedSteps >= 3) {
+            welcomeJourneyAdapter.setFullyCompleted(true)
+        }
     }
 
     private fun handleWelcomeJourneyClick(stepIndex: Int) {
@@ -978,6 +1009,8 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
 
     private fun updateContributionsView(summary: Summary) {
         if (!isAdded) return
+
+        handleWelcomeJourneyState(summary.events)
 
         val isAssociationFromSummary = summary.association == true
         EntourageApplication.get().sharedPreferences.edit {


### PR DESCRIPTION
This commit implements the synchronization of the Home Welcome Journey steps with the backend state. It introduces the `events` property to the `Summary` model and processes these events inside `HomeFragment`'s `handleWelcomeJourneyState` to correctly mark step completions for:
- "onboarding.resource.welcome_watched" (Step 1)
- "onboarding.outing.webinar_or_first_steps" (Step 2)
- "onboarding.outing.papotages" (Step 3)

The local mock behaviors for interactions are maintained but updated to respect the initial server state, preventing duplicate step increments.

---
*PR created automatically by Jules for task [17191615134482054241](https://jules.google.com/task/17191615134482054241) started by @clemPerrousset*