### PR TITLE
Add Shimmer skeleton loader to HomeFragment

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -251,6 +251,7 @@ dependencies {
     //entourageImplementation facebookDependencies.values()
     implementation(libs.facebook.android.sdk)
     implementation(libs.facebook.core)
+    implementation(libs.shimmer)
     compileOnly(libs.javax.annotation)
 
     // Instrumentation tests

--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -104,6 +104,7 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
 
     // Welcome Journey
     private lateinit var welcomeJourneyAdapter: HomeWelcomeJourneyAdapter
+    private val homeSkeletonAdapter = HomeSkeletonAdapter()
     private var currentCompletedSteps = 0
 
 
@@ -511,24 +512,7 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
 
         concatAdapter = ConcatAdapter(
             config,
-            welcomeJourneyAdapter,
-            initialPedagoHeaderAdapter,
-
-            initialPedagoWrapperAdapter,
-            actionHeaderAdapter,
-            actionWrapperAdapter,
-            actionButtonAdapter,
-            eventHeaderAdapter,
-            eventWrapperAdapter,
-            eventButtonAdapter,
-            homeModeratorAdapter,
-            groupHeaderAdapter,
-            groupWrapperAdapter,
-            groupButtonAdapter,
-            horsZoneAdapter,
-            smallTalkWrapperAdapter,
-            homeToolsAdapter,
-            homePedagoAdapter
+            homeSkeletonAdapter
         )
 
         binding.rvHome.apply {
@@ -799,6 +783,28 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
         // CORRECTION: On fait un fade out sur la progress bar plutôt que de changer la visibilité du RV
         // Ça évite le saut de contenu
         if (totalchecksum >= 4) {
+            if (concatAdapter.adapters.contains(homeSkeletonAdapter)) {
+                concatAdapter.removeAdapter(homeSkeletonAdapter)
+                concatAdapter.addAdapter(welcomeJourneyAdapter)
+                concatAdapter.addAdapter(initialPedagoHeaderAdapter)
+                concatAdapter.addAdapter(initialPedagoWrapperAdapter)
+                concatAdapter.addAdapter(actionHeaderAdapter)
+                concatAdapter.addAdapter(actionWrapperAdapter)
+                concatAdapter.addAdapter(actionButtonAdapter)
+                concatAdapter.addAdapter(eventHeaderAdapter)
+                concatAdapter.addAdapter(eventWrapperAdapter)
+                concatAdapter.addAdapter(eventButtonAdapter)
+                concatAdapter.addAdapter(homeModeratorAdapter)
+                concatAdapter.addAdapter(groupHeaderAdapter)
+                concatAdapter.addAdapter(groupWrapperAdapter)
+                concatAdapter.addAdapter(groupButtonAdapter)
+                concatAdapter.addAdapter(horsZoneAdapter)
+                concatAdapter.addAdapter(smallTalkHeaderAdapter)
+                concatAdapter.addAdapter(smallTalkWrapperAdapter)
+                concatAdapter.addAdapter(homeToolsAdapter)
+                concatAdapter.addAdapter(homePedagoAdapter)
+                binding.rvHome.scheduleLayoutAnimation()
+            }
             if (binding.progressBar.visibility == View.VISIBLE) {
                 binding.progressBar.animate()
                     .alpha(0f)

--- a/app/src/main/java/social/entourage/android/home/HomeSkeletonAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeSkeletonAdapter.kt
@@ -1,0 +1,29 @@
+package social.entourage.android.home
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.facebook.shimmer.ShimmerFrameLayout
+import social.entourage.android.R
+
+class HomeSkeletonAdapter : RecyclerView.Adapter<HomeSkeletonAdapter.ViewHolder>() {
+
+    // Number of skeleton sections to show (e.g. Events, Actions, Groups, Pedago)
+    override fun getItemCount(): Int {
+        return 4
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.home_skeleton_horizontal_list, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.shimmerFrameLayout.startShimmer()
+    }
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val shimmerFrameLayout: ShimmerFrameLayout = view.findViewById(R.id.shimmer_view_container)
+    }
+}

--- a/app/src/main/res/layout/home_skeleton_horizontal_list.xml
+++ b/app/src/main/res/layout/home_skeleton_horizontal_list.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="20dp"
+    android:paddingStart="@dimen/entourage_marginstart"
+    android:paddingBottom="20dp">
+
+    <!-- Fake Header -->
+    <View
+        android:id="@+id/skeleton_header_title"
+        android:layout_width="150dp"
+        android:layout_height="20dp"
+        android:background="#E0E0E0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/skeleton_header_subtitle"
+        android:layout_width="200dp"
+        android:layout_height="14dp"
+        android:layout_marginTop="8dp"
+        android:background="#E0E0E0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/skeleton_header_title" />
+
+    <!-- Shimmer for the fake list -->
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:id="@+id/shimmer_view_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/skeleton_header_subtitle"
+        app:shimmer_auto_start="true">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <include layout="@layout/home_skeleton_item" />
+            <include layout="@layout/home_skeleton_item" />
+            <include layout="@layout/home_skeleton_item" />
+
+        </LinearLayout>
+    </com.facebook.shimmer.ShimmerFrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/home_skeleton_item.xml
+++ b/app/src/main/res/layout/home_skeleton_item.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="160dp"
+    android:layout_height="wrap_content"
+    android:layout_marginEnd="16dp"
+    android:background="@drawable/bg_rounded_card"
+    android:clipToPadding="false"
+    android:padding="8dp">
+
+    <View
+        android:id="@+id/skeleton_image"
+        android:layout_width="0dp"
+        android:layout_height="90dp"
+        android:background="#E0E0E0"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:id="@+id/skeleton_title"
+        android:layout_width="0dp"
+        android:layout_height="16dp"
+        android:layout_marginTop="12dp"
+        android:background="#E0E0E0"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/skeleton_image" />
+
+    <View
+        android:id="@+id/skeleton_subtitle1"
+        android:layout_width="100dp"
+        android:layout_height="12dp"
+        android:layout_marginTop="8dp"
+        android:background="#E0E0E0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/skeleton_title" />
+
+    <View
+        android:id="@+id/skeleton_subtitle2"
+        android:layout_width="80dp"
+        android:layout_height="12dp"
+        android:layout_marginTop="8dp"
+        android:background="#E0E0E0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/skeleton_subtitle1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginBottom="8dp"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ glide = "5.0.5"
 shortcut-badger = "1.1.22"
 keyboard-visibility-event = "3.0.0-RC3"
 facebook = "18.1.3"
+shimmer = "0.5.0"
 javax-annotation = "10.0-b28"
 androidx-test-ext-junit = "1.3.0"
 androidx-test-runner = "1.7.0"
@@ -104,6 +105,7 @@ shortcut-badger = { module = "me.leolin:ShortcutBadger", version.ref = "shortcut
 keyboard-visibility-event = { module = "net.yslibrary.keyboardvisibilityevent:keyboardvisibilityevent", version.ref = "keyboard-visibility-event" }
 facebook-android-sdk = { module = "com.facebook.android:facebook-android-sdk", version.ref = "facebook" }
 facebook-core = { module = "com.facebook.android:facebook-core", version.ref = "facebook" }
+shimmer = { module = "com.facebook.shimmer:shimmer", version.ref = "shimmer" }
 javax-annotation = { module = "org.glassfish:javax.annotation", version.ref = "javax-annotation" }
 junit = { module = "junit:junit", version.ref = "junit" }
 test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }


### PR DESCRIPTION
This commit replaces the central progress loader in the Home screen with a `HomeSkeletonAdapter` utilizing Facebook Shimmer. The Home screen now immediately shows simulated skeleton lists, improving perceived loading speed. Once the total API call checksum reaches the threshold, the skeleton adapter is detached, and the real list adapters are inserted sequentially with layout entrance animations.

---
*PR created automatically by Jules for task [16190285824814720829](https://jules.google.com/task/16190285824814720829) started by @clemPerrousset*