### PR TITLE
Fix YouTube error 153 on embedded videos

### DIFF
--- a/app/src/main/java/social/entourage/android/home/pedago/PedagoContentDetailsFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/pedago/PedagoContentDetailsFragment.kt
@@ -81,7 +81,7 @@ class PedagoContentDetailsFragment : Fragment() {
                 setBackgroundColor(Color.TRANSPARENT)
                 settings.javaScriptEnabled = true
                 loadDataWithBaseURL(
-                    null, htmlContent, "text/html", "utf-8", null
+                    "https://www.entourage.social", htmlContent, "text/html", "utf-8", null
                 )
             }
         }


### PR DESCRIPTION
Resolves "Error 153" on embedded YouTube videos within the pedagogical content detail views. This error occurred because the WebView was loading HTML with a `null` base URL, providing an invalid referrer to the YouTube player's origin restriction checks. Setting `https://www.entourage.social` as the base URL fixes the issue safely.

---
*PR created automatically by Jules for task [8480010033841077102](https://jules.google.com/task/8480010033841077102) started by @clemPerrousset*