### PR TITLE
Fix chat soft input resize mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -128,7 +128,7 @@
             android:exported="false" />
         <activity
             android:name=".discussions.DetailConversationActivity"
-            android:windowSoftInputMode="adjustPan"
+            android:windowSoftInputMode="adjustResize"
             android:exported="false" />
         <activity
             android:name=".tools.image_viewer.ImageListActivity"
@@ -155,11 +155,11 @@
             android:exported="false" />
         <activity
             android:name=".events.details.feed.EventCommentActivity"
-            android:windowSoftInputMode="adjustPan"
+            android:windowSoftInputMode="adjustResize"
             android:exported="false" />
         <activity
             android:name=".groups.details.feed.GroupCommentActivity"
-            android:windowSoftInputMode="adjustPan"
+            android:windowSoftInputMode="adjustResize"
             android:exported="false" />
         <activity
             android:name=".events.details.feed.EventFeedActivity"
@@ -188,7 +188,7 @@
         <!-- abstract class declared here to make sure child classes work -->
         <activity
             android:name=".comment.CommentActivity"
-            android:windowSoftInputMode="adjustPan"
+            android:windowSoftInputMode="adjustResize"
             android:exported="false" />
 
         <activity

--- a/app/src/main/java/social/entourage/android/comment/CommentActivity.kt
+++ b/app/src/main/java/social/entourage/android/comment/CommentActivity.kt
@@ -12,6 +12,8 @@ import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
 import social.entourage.android.EntourageApplication
@@ -95,7 +97,14 @@ override fun onCreate(savedInstanceState: Bundle?) {
 
     handleSendButtonState()
 
+
     updatePaddingTopForEdgeToEdge(binding.header.headerLayout)
+
+    ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, windowInsets ->
+        val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.ime())
+        view.setPadding(0, 0, 0, insets.bottom)
+        windowInsets
+    }
 }
 
 fun setIsEventTrue(){

--- a/app/src/main/res/layout/home_skeleton_item.xml
+++ b/app/src/main/res/layout/home_skeleton_item.xml
@@ -4,7 +4,7 @@
     android:layout_width="160dp"
     android:layout_height="wrap_content"
     android:layout_marginEnd="16dp"
-    android:background="@drawable/bg_rounded_card"
+    android:background="@drawable/rounded_layout"
     android:clipToPadding="false"
     android:padding="8dp">
 

--- a/app/src/main/res/layout/home_skeleton_item.xml
+++ b/app/src/main/res/layout/home_skeleton_item.xml
@@ -4,7 +4,7 @@
     android:layout_width="160dp"
     android:layout_height="wrap_content"
     android:layout_marginEnd="16dp"
-    android:background="@drawable/rounded_layout"
+    android:background="@drawable/bg_rounded_card"
     android:clipToPadding="false"
     android:padding="8dp">
 


### PR DESCRIPTION
Update windowSoftInputMode for chat and comment activities to adjustResize

This change updates the `windowSoftInputMode` from `adjustPan` to `adjustResize` in `AndroidManifest.xml` for `DetailConversationActivity`, `CommentActivity`, `EventCommentActivity`, and `GroupCommentActivity`. This resolves the issue where the keyboard pushing up the `EditText` shifts the entire screen inappropriately (covering top bars or cutting off content) instead of properly resizing the `RecyclerView` list of messages like standard chat applications do.

---
*PR created automatically by Jules for task [8381259672373827602](https://jules.google.com/task/8381259672373827602) started by @clemPerrousset*