### PR TITLE
Migrate Welcome Journey Links to Native Lists

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -116,6 +116,10 @@
             android:exported="false"/>
         <activity android:name=".small_talks.SmallTalkNoBandFound"
             android:exported="false"/>
+        <activity android:name=".events.list.WelcomeEventsListActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.EntourageSocial" />
         <activity android:name=".comment.ImageZoomActivity"
             />
         <activity

--- a/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
+++ b/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
@@ -118,6 +118,12 @@ interface EventsRequest {
     @GET("outings/first_steps")
     fun getEventWelcome(): Call<EventWrapper>
 
+    @GET("outings/papotages")
+    fun getEventsPapotages(): Call<EventsListWrapper>
+
+    @GET("outings/webinar")
+    fun getEventsWebinar(): Call<EventsListWrapper>
+
     @POST("outings/{event_id}/users")
     fun participate(
         @Path("event_id") eventId: Int

--- a/app/src/main/java/social/entourage/android/events/EventsPresenter.kt
+++ b/app/src/main/java/social/entourage/android/events/EventsPresenter.kt
@@ -39,6 +39,8 @@ class EventsPresenter : ViewModel() {
     var getFilteredEvents = MutableLiveData<MutableList<Events>>()
     var getFilteredMyEvents = MutableLiveData<MutableList<Events>>()
     var getEvent = MutableLiveData<Events>()
+    var getEventsPapotages = MutableLiveData<MutableList<Events>>()
+    var getEventsWebinar = MutableLiveData<MutableList<Events>>()
     var isEventReported = MutableLiveData<Boolean>()
     var isEventDeleted = MutableLiveData<Boolean>()
     var isEventPostReported = MutableLiveData<Boolean>()
@@ -157,6 +159,46 @@ class EventsPresenter : ViewModel() {
                 }
 
                 override fun onFailure(call: Call<EventsListWrapper>, t: Throwable) {
+                }
+            })
+    }
+
+    fun getEventsPapotages() {
+        EntourageApplication.get().apiModule.eventsRequest.getEventsPapotages()
+            .enqueue(object : Callback<EventsListWrapper> {
+                override fun onResponse(
+                    call: Call<EventsListWrapper>,
+                    response: Response<EventsListWrapper>
+                ) {
+                    if (response.isSuccessful) {
+                        response.body()?.let { eventsListWrapper ->
+                            getEventsPapotages.value = eventsListWrapper.allEvents
+                        }
+                    }
+                }
+
+                override fun onFailure(call: Call<EventsListWrapper>, t: Throwable) {
+                    Timber.wtf("wtf error " + t.message)
+                }
+            })
+    }
+
+    fun getEventsWebinar() {
+        EntourageApplication.get().apiModule.eventsRequest.getEventsWebinar()
+            .enqueue(object : Callback<EventsListWrapper> {
+                override fun onResponse(
+                    call: Call<EventsListWrapper>,
+                    response: Response<EventsListWrapper>
+                ) {
+                    if (response.isSuccessful) {
+                        response.body()?.let { eventsListWrapper ->
+                            getEventsWebinar.value = eventsListWrapper.allEvents
+                        }
+                    }
+                }
+
+                override fun onFailure(call: Call<EventsListWrapper>, t: Throwable) {
+                    Timber.wtf("wtf error " + t.message)
                 }
             })
     }

--- a/app/src/main/java/social/entourage/android/events/list/WelcomeEventsListActivity.kt
+++ b/app/src/main/java/social/entourage/android/events/list/WelcomeEventsListActivity.kt
@@ -1,0 +1,63 @@
+package social.entourage.android.events.list
+
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.LinearLayoutManager
+import social.entourage.android.EntourageApplication
+import social.entourage.android.R
+import social.entourage.android.databinding.ActivityWelcomeEventsListBinding
+import social.entourage.android.events.EventsPresenter
+import social.entourage.android.api.model.Events
+
+class WelcomeEventsListActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityWelcomeEventsListBinding
+    private lateinit var eventsPresenter: EventsPresenter
+    private lateinit var eventsAdapter: AllEventAdapter
+    private var myId: Int? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityWelcomeEventsListBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val type = intent.getStringExtra("TYPE") ?: "papotages"
+
+        eventsPresenter = ViewModelProvider(this).get(EventsPresenter::class.java)
+        myId = EntourageApplication.me(this)?.id
+        eventsAdapter = AllEventAdapter(myId, this)
+
+        binding.recyclerView.apply {
+            layoutManager = LinearLayoutManager(this@WelcomeEventsListActivity)
+            adapter = eventsAdapter
+        }
+
+        binding.header.iconBack.setOnClickListener {
+            finish()
+        }
+
+        if (type == "webinar") {
+            binding.header.title = getString(R.string.title_welcome_webinar)
+            eventsPresenter.getEventsWebinar.observe(this, ::handleEventsResponse)
+            eventsPresenter.getEventsWebinar()
+        } else {
+            binding.header.title = getString(R.string.title_welcome_papotages)
+            eventsPresenter.getEventsPapotages.observe(this, ::handleEventsResponse)
+            eventsPresenter.getEventsPapotages()
+        }
+    }
+
+    private fun handleEventsResponse(events: MutableList<Events>?) {
+        binding.progressBar.visibility = View.GONE
+        if (events != null && events.isNotEmpty()) {
+            eventsAdapter.resetData(events)
+            binding.emptyStateLayout.visibility = View.GONE
+            binding.recyclerView.visibility = View.VISIBLE
+        } else {
+            binding.emptyStateLayout.visibility = View.VISIBLE
+            binding.recyclerView.visibility = View.GONE
+        }
+    }
+}

--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -243,22 +243,14 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
         when (stepIndex) {
             1 -> showVideoModal()
             2 -> {
-                val urlString = if (BuildConfig.DEBUG) {
-                    "https://preprod.entourage.social/app/outings/webinar"
-                } else {
-                    "https://www.entourage.social/app/outings/webinar"
-                }
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(urlString))
+                val intent = Intent(requireContext(), social.entourage.android.events.list.WelcomeEventsListActivity::class.java)
+                intent.putExtra("TYPE", "webinar")
                 startActivity(intent)
                 updateWelcomeJourneyStep(2)
             }
             3 -> {
-                val urlString = if (BuildConfig.DEBUG) {
-                    "https://preprod.entourage.social/app/outings/papotages"
-                } else {
-                    "https://www.entourage.social/app/outings/papotages"
-                }
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(urlString))
+                val intent = Intent(requireContext(), social.entourage.android.events.list.WelcomeEventsListActivity::class.java)
+                intent.putExtra("TYPE", "papotages")
                 startActivity(intent)
                 updateWelcomeJourneyStep(3)
             }

--- a/app/src/main/res/layout/activity_welcome_events_list.xml
+++ b/app/src/main/res/layout/activity_welcome_events_list.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white">
+
+    <include
+        android:id="@+id/header"
+        layout="@layout/new_main_header" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:paddingTop="16dp"
+        android:clipToPadding="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/header" />
+
+    <LinearLayout
+        android:id="@+id/emptyStateLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/header">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/no_events_found"
+            android:textColor="@color/black"
+            android:textSize="16sp" />
+    </LinearLayout>
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
     <string name="app_name" translatable="false">Entourage</string>
     <string name="full_app_name">Entourage</string>
     <string name="button_loading">Chargement…</string>
+    <string name="title_welcome_webinar">Prochaines visios</string>
+    <string name="title_welcome_papotages">Prochains papotages</string>
     <string name="error_not_yet_implemented">Indisponible</string>
     <string name="error_google_play_store_not_installed">Le Google Play Store n\'est pas intallé</string>
     <string name="error_application_update">La version d\'Entourage installée n\'est plus supportée. Pour pouvoir continuer à utiliser nos services et profiter de la meilleure expérience possible, veuillez la mettre à jour avec la dernière version en cliquant sur le lien suivant.</string>
@@ -17,6 +19,7 @@
     <string name="register">Enregistrer</string>
     <string name="ignore">Ignorer</string>
     <string name="continue_string">Continuer</string>
+    <string name="no_events_found">Aucun événement trouvé</string>
     <string name="close">Fermer</string>
     <string name="edit">Modifier</string>
     <string name="activate">Activer</string>


### PR DESCRIPTION
The user requested that the "Prochaines visios" (Webinar) and "Prochains papotages" links in the Home screen's Welcome Journey be replaced. Previously, these links opened a web browser / intent with deep links. They should now open native Android list views populated by two new API endpoints (`/api/v1/outings/webinar` and `/api/v1/outings/papotages`), reusing existing UI components (like `AllEventAdapter` and `EventDetailActivity` on click).

**Changes made:**
1.  **Network Layer:** Added `getEventsPapotages` and `getEventsWebinar` endpoints to `EventsRequest.kt`.
2.  **Presenter:** Added matching methods and `MutableLiveData` to `EventsPresenter.kt`.
3.  **UI:** Created `WelcomeEventsListActivity.kt` and its layout (`activity_welcome_events_list.xml`). This is a generic activity that looks for a `"TYPE"` intent extra to decide which presenter method to call and which title to display. It reuses the `AllEventAdapter` to maintain visual consistency with other event lists.
4.  **Integration:** Modified the click listeners in `HomeFragment.kt`'s `handleWelcomeJourneyClick` to fire an Intent to the new activity with the correct type (`"webinar"` or `"papotages"`).
5.  **Resources:** Declared the activity in `AndroidManifest.xml` and added the necessary titles and "empty state" strings to `strings.xml`.

---
*PR created automatically by Jules for task [1719120168567455122](https://jules.google.com/task/1719120168567455122) started by @clemPerrousset*