### PR TITLE
Fix: Prevent placeholder text being sent with image-only posts

### DIFF
--- a/app/src/main/java/social/entourage/android/comment/CommentActivity.kt
+++ b/app/src/main/java/social/entourage/android/comment/CommentActivity.kt
@@ -275,11 +275,16 @@ fun updateView(emptyState: Boolean) {
     private fun handleCommentAction() {
     binding.comment.setOnClickListener {
         // Convertir le contenu de l'EditText en HTML pour préserver les retours à la ligne
-        val message = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            Html.toHtml(binding.commentMessage.text, Html.TO_HTML_PARAGRAPH_LINES_INDIVIDUAL)
+        val rawText = binding.commentMessage.text.toString().trim()
+        val message = if (rawText.isEmpty()) {
+            ""
         } else {
-            @Suppress("DEPRECATION")
-            Html.toHtml(binding.commentMessage.text)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                Html.toHtml(binding.commentMessage.text, Html.TO_HTML_PARAGRAPH_LINES_INDIVIDUAL)
+            } else {
+                @Suppress("DEPRECATION")
+                Html.toHtml(binding.commentMessage.text)
+            }
         }
 
         if (message.isNotBlank() || photoUri != null) {

--- a/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DetailConversationActivity.kt
@@ -555,12 +555,16 @@ class DetailConversationActivity : CommentActivity() {
             return
         }
         val spanned = binding.commentMessage.editableText
-        val caption = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            Html.toHtml(spanned, Html.FROM_HTML_MODE_LEGACY)
+        val caption = if (spanned.toString().trim().isEmpty()) {
+            null
         } else {
-            @Suppress("DEPRECATION")
-            Html.toHtml(spanned)
-        }.trim().ifEmpty { null }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                Html.toHtml(spanned, Html.FROM_HTML_MODE_LEGACY)
+            } else {
+                @Suppress("DEPRECATION")
+                Html.toHtml(spanned)
+            }.trim().ifEmpty { null }
+        }
         if (isSmallTalkMode) {
             smallTalkViewModel.addMessageWithImage(smallTalkId, caption, file)
         } else if (detailConversation?.type == "outing") {

--- a/app/src/main/java/social/entourage/android/events/details/feed/CreatePostEventActivity.kt
+++ b/app/src/main/java/social/entourage/android/events/details/feed/CreatePostEventActivity.kt
@@ -39,7 +39,9 @@ class CreatePostEventActivity : CreatePostActivity() {
 
     // Publication d'un post avec image
     override fun addPostWithImage(file: File) {
-        eventPresenter.addPost(binding.message.text.toString(), file, groupId)
+        val messageText = binding.message.text.toString().trim()
+        val finalMessage = if (messageText.isEmpty()) null else messageText
+        eventPresenter.addPost(finalMessage, file, groupId)
     }
 
     // Publication d'un post sans image

--- a/app/src/main/java/social/entourage/android/events/details/feed/EventCommentActivity.kt
+++ b/app/src/main/java/social/entourage/android/events/details/feed/EventCommentActivity.kt
@@ -131,8 +131,12 @@ class EventCommentActivity : CommentActivity() {
         // 3) Vérifie s'il y a une balise <a href="...">
         val hasLink = fullHtml.contains("<a href=")
 
-        // 4) Choix final : HTML ou texte brut
-        val finalContent = if (hasLink) fullHtml else spannedText.toString()
+        // 4) Choix final : HTML ou texte brut (et on vérifie qu'il n'est pas vide pour l'image)
+        val finalContent = if (spannedText.toString().trim().isEmpty()) {
+            null
+        } else {
+            if (hasLink) fullHtml else spannedText.toString()
+        }
 
         // 5) Construit le Post
         val currentUserId = EntourageApplication.me(this)?.id ?: 0

--- a/app/src/main/java/social/entourage/android/groups/details/feed/CreatePostGroupActivity.kt
+++ b/app/src/main/java/social/entourage/android/groups/details/feed/CreatePostGroupActivity.kt
@@ -47,8 +47,11 @@ class CreatePostGroupActivity : CreatePostActivity() {
 
     // Publication d'un post avec image
     override fun addPostWithImage(file: File) {
+        val messageText = binding.message.text.toString().trim()
+        val finalMessage = if (messageText.isEmpty()) null else messageText
+
         groupPresenter.addPost(
-            binding.message.text.toString(),
+            finalMessage,
             file,
             groupId
         )

--- a/app/src/main/java/social/entourage/android/groups/details/feed/GroupCommentActivity.kt
+++ b/app/src/main/java/social/entourage/android/groups/details/feed/GroupCommentActivity.kt
@@ -96,11 +96,15 @@ class GroupCommentActivity : CommentActivity() {
         // 3) Vérifie si on a un lien <a href="...">
         val hasLink = fullHtml.contains("<a href=")
 
-        // 4) Choix final du contenu
-        val finalContent = if (hasLink) {
-            fullHtml
+        // 4) Choix final du contenu (et on vérifie qu'il n'est pas vide)
+        val finalContent = if (spannedText.toString().trim().isEmpty()) {
+            null
         } else {
-            spannedText.toString()
+            if (hasLink) {
+                fullHtml
+            } else {
+                spannedText.toString()
+            }
         }
 
         // 5) Construit le Post comme dans l'ancienne version


### PR DESCRIPTION
This fixes the bug where "Écrire un message" (the placeholder/hint) would be sent and displayed when a user posts only an image without typing any text, across Groups, Events, and Messaging.

The issue occurred because the app was converting the empty `EditText`'s content to HTML before sending. `Html.toHtml()` on an empty string returns empty tags like `<p dir="ltr"></p>\n`. Because the resulting string was technically not empty, the backend accepted it. On the receiving end, it rendered as invisible content but caused the `TextView` to show its default hint text since there was a "message" but it was visually blank. 

I've added explicit checks across all relevant post and comment creation flows to verify if the raw text is empty (`.trim().isEmpty()`). If it is, the code now properly passes `null` or an empty string, bypassing the HTML conversion entirely.

---
*PR created automatically by Jules for task [17479561161585791817](https://jules.google.com/task/17479561161585791817) started by @clemPerrousset*