### PR TITLE
Fix recurrent event edit dialog "Validate" button state

### DIFF
--- a/app/src/main/java/social/entourage/android/events/create/CreateEventFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventFragment.kt
@@ -170,20 +170,25 @@ class CreateEventFragment : Fragment() {
         val cancelOneEvent = customDialog.findViewById<RadioButton>(R.id.one_event)
         val cancelAllEvents =
             customDialog.findViewById<RadioButton>(R.id.all_events_recurrent)
+        val radioGroup = customDialog.findViewById<android.widget.RadioGroup>(R.id.recurrence)
 
-
-        //buttonYes.background = requireContext().getDrawable(R.drawable.btn_shape_orange_alert_dialog)
-
-        with(customDialog.findViewById<Button>(R.id.yes)) {
-           this.background = requireContext().getDrawable(R.drawable.btn_shape_light_orange)
-
+        val btnYes = customDialog.findViewById<Button>(R.id.yes)
+        with(btnYes) {
+            this.background = requireContext().getDrawable(R.drawable.btn_shape_light_orange)
             text = getString(R.string.validate)
+            isEnabled = false
+
             setOnClickListener {
                 if (cancelOneEvent.isChecked) updateEventWithoutRecurrence()
                 if (cancelAllEvents.isChecked) updateEventWithRecurrence()
                 alertDialog.dismiss()
                 activity?.finish()
             }
+        }
+
+        radioGroup.setOnCheckedChangeListener { _, _ ->
+            btnYes.isEnabled = true
+            btnYes.background = requireContext().getDrawable(R.drawable.btn_shape_orange_alert_dialog)
         }
         customDialog.findViewById<TextView>(R.id.title).text =
             getString(R.string.event_edit_recurrent_event)


### PR DESCRIPTION
Fixes a bug where the "Valider" button in the recurrent event editing modal was permanently grayed out. The button is now initially disabled and becomes active (changing color to full orange) only after the user selects either "this event" or "all events" to apply changes.

---
*PR created automatically by Jules for task [17677774774606169547](https://jules.google.com/task/17677774774606169547) started by @clemPerrousset*