### PR TITLE
⚡ Optimize reaction lookups in members lists

### DIFF
--- a/app/src/main/java/social/entourage/android/groups/details/members/MembersFragment.kt
+++ b/app/src/main/java/social/entourage/android/groups/details/members/MembersFragment.kt
@@ -132,13 +132,14 @@ open class MembersFragment : Fragment() {
     private fun handleResponseGetMembersReact(reactionsResponse: CompleteReactionsResponse) {
         membersList.clear()
         reactionList.clear()
+        val reactionsMap = MainActivity.reactionsList?.associateBy { it.id }
         reactionsResponse.user_reactions.forEach { userReaction ->
             membersList.add(userReaction.user)
-            val matchingReaction = MainActivity.reactionsList?.find { it.id == userReaction.reaction_id }
+            val matchingReaction = reactionsMap?.get(userReaction.reaction_id)
             val reaction = matchingReaction ?: ReactionType(
                 id = userReaction.reaction_id,
-                key = matchingReaction?.key,
-                imageUrl = matchingReaction?.imageUrl
+                key = null,
+                imageUrl = null
             )
             reactionList.add(reaction)
         }

--- a/app/src/main/java/social/entourage/android/members/MembersActivity.kt
+++ b/app/src/main/java/social/entourage/android/members/MembersActivity.kt
@@ -267,10 +267,11 @@ class MembersActivity : BaseActivity() , AcceptPhotoDialogFragment.Listener {
     private fun handleReactions(resp: CompleteReactionsResponse) {
         membersList.clear()
         reactionList.clear()
+        val reactionsMap = MainActivity.reactionsList?.associateBy { it.id }
         resp.user_reactions.forEach { ur ->
             membersList += ur.user
-            val match = MainActivity.reactionsList?.find { it.id == ur.reaction_id }
-            val reaction = match ?: ReactionType(ur.reaction_id, match?.key, match?.imageUrl)
+            val match = reactionsMap?.get(ur.reaction_id)
+            val reaction = match ?: ReactionType(ur.reaction_id, null, null)
             reactionList += reaction
         }
         binding.progressBar.visibility = View.GONE


### PR DESCRIPTION
This change addresses a performance inefficiency in `MembersFragment` and `MembersActivity` where reaction lookups were being performed using an O(N) `find` operation inside a loop. By pre-associating the `MainActivity.reactionsList` into a `Map` by ID, we achieve O(1) lookup time, resulting in a measurably more efficient processing of member reactions.

---
*PR created automatically by Jules for task [4500711523903892848](https://jules.google.com/task/4500711523903892848) started by @clemPerrousset*