### PR TITLE
Update welcome events deep links to use WelcomeEventsListActivity

### DIFF
--- a/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
+++ b/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
@@ -115,8 +115,6 @@ interface EventsRequest {
     @GET("outings/sensibilisation")
     fun getEventSensibilisation(): Call<EventWrapper>
 
-    @GET("outings/first_steps")
-    fun getEventWelcome(): Call<EventWrapper>
 
     @GET("outings/firsts_steps")
     fun getEventListWelcome(): Call<EventsListWrapper>

--- a/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
+++ b/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
@@ -235,14 +235,23 @@ class UniversalLinkManager(val context:Context):UniversalLinksPresenterCallback 
 
     private fun handleOutings(pathSegments: List<String>) {
         if (pathSegments.contains("papotages")) {
-            presenter.getEventSmallTalk()
+            val intent = Intent(context, social.entourage.android.events.list.WelcomeEventsListActivity::class.java)
+            intent.putExtra("TYPE", "papotages")
+            context.startActivity(intent)
+            (context as? Activity)?.overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
         } else if (pathSegments.contains("new")) {
             val intent = Intent(context, social.entourage.android.events.create.CreateEventActivity::class.java)
             (context as? MainActivity)?.startActivityForResult(intent, 0)
         } else if (pathSegments.contains("webinar")) {
-            presenter.getEventSensibilisation()
+            val intent = Intent(context, social.entourage.android.events.list.WelcomeEventsListActivity::class.java)
+            intent.putExtra("TYPE", "webinar")
+            context.startActivity(intent)
+            (context as? Activity)?.overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
         } else if (pathSegments.contains("welcome")) {
-            presenter.getEventWelcome()
+            val intent = Intent(context, social.entourage.android.events.list.WelcomeEventsListActivity::class.java)
+            intent.putExtra("TYPE", "papotages")
+            context.startActivity(intent)
+            (context as? Activity)?.overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
         } else if (pathSegments.size > 3) {
             val outingId = pathSegments[2]
             EventFeedFragment.shouldAddToAgenda = true

--- a/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkPresenter.kt
+++ b/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkPresenter.kt
@@ -154,74 +154,8 @@ class UniversalLinkPresenter(val callback:UniversalLinksPresenterCallback) {
             })
     }
 
-    fun getEventSmallTalk() {
-        EntourageApplication.get().apiModule.eventsRequest.getEventSmallTalk()
-            .enqueue(object : Callback<EventWrapper> {
-                override fun onResponse(
-                    call: Call<EventWrapper>,
-                    response: Response<EventWrapper>
-                ) {
-                    if (response.isSuccessful) {
-                        response.body()?.let { eventWrapper ->
-                            callback.onRetrievedEvent(eventWrapper.event)
-                        }
-                    }
-                    if(response.code() >= 400){
-                        callback.onErrorRetrievedEvent()
-                    }
-                }
 
-                override fun onFailure(call: Call<EventWrapper>, t: Throwable) {
-                    callback.onErrorRetrievedEvent()
-                }
-            })
-    }
 
-    fun getEventWelcome() {
-        EntourageApplication.get().apiModule.eventsRequest.getEventWelcome()
-            .enqueue(object : Callback<EventWrapper> {
-                override fun onResponse(
-                    call: Call<EventWrapper>,
-                    response: Response<EventWrapper>
-                ) {
-                    if (response.isSuccessful) {
-                        response.body()?.let { eventWrapper ->
-                            callback.onRetrievedEvent(eventWrapper.event)
-                        }
-                    }
-                    if(response.code() >= 400){
-                        callback.onErrorRetrievedEvent()
-                    }
-                }
-
-                override fun onFailure(call: Call<EventWrapper>, t: Throwable) {
-                    callback.onErrorRetrievedEvent()
-                }
-            })
-    }
-
-    fun getEventSensibilisation() {
-        EntourageApplication.get().apiModule.eventsRequest.getEventSensibilisation()
-            .enqueue(object : Callback<EventWrapper> {
-                override fun onResponse(
-                    call: Call<EventWrapper>,
-                    response: Response<EventWrapper>
-                ) {
-                    if (response.isSuccessful) {
-                        response.body()?.let { eventWrapper ->
-                            callback.onRetrievedEvent(eventWrapper.event)
-                        }
-                    }
-                    if(response.code() >= 400){
-                        callback.onErrorRetrievedEvent()
-                    }
-                }
-
-                override fun onFailure(call: Call<EventWrapper>, t: Throwable) {
-                    callback.onErrorRetrievedEvent()
-                }
-            })
-    }
 }
 
 interface UniversalLinksPresenterCallback{


### PR DESCRIPTION
Updated the routing logic in `UniversalLinkManager.kt` so that URLs matching "papotages", "welcome", and "webinar" now open the unified list activity `WelcomeEventsListActivity` (with the appropriate `TYPE` arguments `"papotages"` or `"webinar"`) rather than calling individual presenter API endpoints to load single events.

Additionally, removed unused presenter methods and an API endpoint `getEventWelcome()` since it is no longer needed across the application.

---
*PR created automatically by Jules for task [3635033028594635551](https://jules.google.com/task/3635033028594635551) started by @clemPerrousset*