### PR TITLE
Add missing country flags and dynamic phone number placeholders

### DIFF
--- a/app/src/main/java/social/entourage/android/onboarding/login/LoginActivity.kt
+++ b/app/src/main/java/social/entourage/android/onboarding/login/LoginActivity.kt
@@ -91,8 +91,21 @@ class LoginActivity : BaseActivity() {
         return getInputText(view).isNotEmpty()
     }
 
+    private fun updatePlaceholder(countryCode: String) {
+        binding.uiLoginPhoneInputLayout.placeholderText = Utils.getPhoneNumberPlaceholder(countryCode)
+    }
+
     private fun setupViews() {
         setEditTextAlignmentBasedOnLocale()
+
+        binding.uiLoginPhoneCcpCode.countryCodePickerListener = object : social.entourage.android.tools.view.countrycodepicker.CountryCodePickerListener {
+            override fun updatedCountry(country: social.entourage.android.tools.view.countrycodepicker.Country) {
+                updatePlaceholder(country.phoneCode)
+            }
+        }
+
+        val initialCountryCode = binding.uiLoginPhoneCcpCode.selectedCountry?.phoneCode ?: "33"
+        updatePlaceholder(initialCountryCode)
 
         binding.iconBack?.setOnClickListener {
             goBack()

--- a/app/src/main/java/social/entourage/android/onboarding/onboard/OnboardingPhase1Fragment.kt
+++ b/app/src/main/java/social/entourage/android/onboarding/onboard/OnboardingPhase1Fragment.kt
@@ -140,6 +140,10 @@ class OnboardingPhase1Fragment : Fragment() {
 
     // ------------------ UI Setup ------------------
 
+    private fun updatePlaceholder(countryCode: String) {
+        binding.tilPhone.placeholderText = social.entourage.android.tools.utils.Utils.getPhoneNumberPlaceholder(countryCode)
+    }
+
     private fun setupViews() {
         setEditTextAlignmentBasedOnLocale()
 
@@ -187,9 +191,13 @@ class OnboardingPhase1Fragment : Fragment() {
         binding.uiOnboardPhoneCcpCode.countryCodePickerListener = object : CountryCodePickerListener {
             override fun updatedCountry(newCountry: Country) {
                 country = newCountry
+                updatePlaceholder(newCountry.phoneCode)
                 updateButtonNext()
             }
         }
+
+        val initialCountryCode = binding.uiOnboardPhoneCcpCode.selectedCountry?.phoneCode ?: "33"
+        updatePlaceholder(initialCountryCode)
 
         // Cachés au départ
         binding.tilCompany.isVisible = false

--- a/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
+++ b/app/src/main/java/social/entourage/android/tools/utils/Utils.kt
@@ -47,6 +47,16 @@ import java.util.Date
 import kotlin.math.max
 
 object Utils {
+    fun getPhoneNumberPlaceholder(countryCode: String): String {
+        return when (countryCode) {
+            "33" -> "06 XX XX XX XX" // France
+            "262" -> "06 92 XX XX XX" // La Réunion
+            "590" -> "06 90 XX XX XX" // Guadeloupe
+            "212" -> "6 XX XX XX XX" // Maroc
+            else -> "XX XX XX XX XX" // Autres
+        }
+    }
+
     fun showToast(context: Context, message: String) {
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
     }

--- a/app/src/main/java/social/entourage/android/tools/view/countrycodepicker/CountryList.kt
+++ b/app/src/main/java/social/entourage/android/tools/view/countrycodepicker/CountryList.kt
@@ -354,7 +354,8 @@ internal object CountryList {
         newCountries.add(
             Country(context.getString(R.string.country_guadeloupe_code),
                 context.getString(R.string.country_guadeloupe_number),
-                context.getString(R.string.country_guadeloupe_name))
+                context.getString(R.string.country_guadeloupe_name),
+                context.getString(R.string.country_guadeloupe_flag))
         )
         newCountries.add(
             Country(context.getString(R.string.country_guatemala_code),
@@ -609,7 +610,8 @@ internal object CountryList {
         newCountries.add(
             Country(context.getString(R.string.country_morocco_code),
                 context.getString(R.string.country_morocco_number),
-                context.getString(R.string.country_morocco_name))
+                context.getString(R.string.country_morocco_name),
+                context.getString(R.string.country_morocco_flag))
         )
         newCountries.add(
             Country(context.getString(R.string.country_mozambique_code),
@@ -719,7 +721,8 @@ internal object CountryList {
         newCountries.add(
             Country(context.getString(R.string.country_reunion_code),
                 context.getString(R.string.country_reunion_number),
-                context.getString(R.string.country_reunion_name))
+                context.getString(R.string.country_reunion_name),
+                context.getString(R.string.country_reunion_flag))
         )
         newCountries.add(
             Country(context.getString(R.string.country_romania_code),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1266,6 +1266,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="country_morocco_name">Maroc</string>
     <string name="country_morocco_code">ma</string>
     <string name="country_morocco_number" translatable="false">212</string>
+    <string name="country_morocco_flag" translatable="false">🇲🇦</string>
 
     <string name="country_mozambique_name">Mozambique</string>
     <string name="country_mozambique_code">mz</string>


### PR DESCRIPTION
This submission fulfills the requirements to display missing flags for La Réunion, Guadeloupe, and Maroc, and conditions the phone placeholder based on the selected country phone code.

---
*PR created automatically by Jules for task [834188238185129607](https://jules.google.com/task/834188238185129607) started by @clemPerrousset*