### PR TITLE
fix: Masquer la bannière staff par défaut dans les commentaires

### DIFF
--- a/app/src/main/java/social/entourage/android/groups/details/feed/GroupCommentActivity.kt
+++ b/app/src/main/java/social/entourage/android/groups/details/feed/GroupCommentActivity.kt
@@ -71,7 +71,6 @@ class GroupCommentActivity : CommentActivity() {
 
     override fun onResume() {
         super.onResume()
-        binding.layoutStaffBanner.visibility = View.GONE
         this.isGroup = true
     }
 

--- a/app/src/main/res/layout/activity_comments.xml
+++ b/app/src/main/res/layout/activity_comments.xml
@@ -348,7 +348,7 @@
             android:paddingTop="12dp"
             android:paddingBottom="12dp"
             android:paddingEnd="8dp"
-            android:visibility="visible"
+            android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@+id/post_comment"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent">


### PR DESCRIPTION
Fix pour la bannière staff "équipe indisponible" qui s'affichait dans toutes les conversations et sans pouvoir être fermée, à cause de son layout visible par défaut.

---
*PR created automatically by Jules for task [5605994197775614504](https://jules.google.com/task/5605994197775614504) started by @clemPerrousset*