### PR TITLE
feat: Enable conversation deletion functionally across conversation contexts

### DIFF
--- a/app/src/main/java/social/entourage/android/discussions/DiscussionsListAdapter.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DiscussionsListAdapter.kt
@@ -17,9 +17,16 @@ import java.util.*
 class DiscussionsListAdapter(
     private val messagesList: MutableList<Conversation>
 ) : RecyclerView.Adapter<DiscussionsListAdapter.ViewHolder>() {
+    var isDeletionMode: Boolean = false
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
+
 
     interface OnItemClickListener {
         fun onItemClick(position: Int, conversation: Conversation)
+        fun onItemLongClick(position: Int, conversation: Conversation): Boolean
     }
 
     private var onItemClickListener: OnItemClickListener? = null
@@ -54,7 +61,26 @@ class DiscussionsListAdapter(
         fun bind(conversation: Conversation) {
             // Gestion du clic
             binding.layout.setOnClickListener {
+                if (isDeletionMode) {
+                    onItemClickListener?.onItemClick(adapterPosition, conversation)
+                } else {
+                    onItemClickListener?.onItemClick(adapterPosition, conversation)
+                }
+            }
+            binding.layout.setOnLongClickListener {
+                onItemClickListener?.onItemLongClick(adapterPosition, conversation) ?: false
+            }
+            binding.iconDelete.setOnClickListener {
                 onItemClickListener?.onItemClick(adapterPosition, conversation)
+            }
+
+            if (isDeletionMode) {
+                binding.iconDelete.visibility = View.VISIBLE
+                binding.date.visibility = View.INVISIBLE
+                binding.dateEvent.visibility = View.INVISIBLE
+                binding.nbUnread.visibility = View.INVISIBLE
+            } else {
+                binding.iconDelete.visibility = View.GONE
             }
 
             // === Affichage de l'image/avatar ===
@@ -116,46 +142,52 @@ class DiscussionsListAdapter(
             }
             binding.name.text = nameToDisplay
 
-            if (conversation.type == "outing") {
-                binding.date.visibility = View.GONE
-                binding.dateEvent.visibility = View.VISIBLE
-                binding.dateEvent.text = conversation.subname
-            } else {
-                binding.date.visibility = View.VISIBLE
-                binding.dateEvent.visibility = View.GONE
-                binding.date.text = conversation.dateFormattedString(binding.root.context)
-            }
+            if (!isDeletionMode) {
+    if (conversation.type == "outing") {
+                    binding.date.visibility = View.GONE
+                    binding.dateEvent.visibility = View.VISIBLE
+                    binding.dateEvent.text = conversation.subname
+                } else {
+                    binding.date.visibility = View.VISIBLE
+                    binding.dateEvent.visibility = View.GONE
+                    binding.date.text = conversation.dateFormattedString(binding.root.context)
+                }
 
-            // === Rôles ===
-            if (!conversation.getRolesWithPartnerFormated().isNullOrEmpty()) {
-                binding.role.visibility = View.VISIBLE
-                binding.role.text = conversation.getRolesWithPartnerFormated()
-            } else {
-                binding.role.visibility = View.GONE
-            }
+                // === Rôles ===
+                if (!conversation.getRolesWithPartnerFormated().isNullOrEmpty()) {
+                    binding.role.visibility = View.VISIBLE
+                    binding.role.text = conversation.getRolesWithPartnerFormated()
+                } else {
+                    binding.role.visibility = View.GONE
+                }
 
-            // === Dernier message ===
-            binding.detail.text = conversation.getLastMessage(context = binding.root.context)
+                // === Dernier message ===
+                binding.detail.text = conversation.getLastMessage(context = binding.root.context)
 
-            // === État "lu/non lu" ===
-            if (conversation.hasUnread()) {
-                binding.nbUnread.visibility = View.VISIBLE
-                binding.nbUnread.text = conversation.numberUnreadMessages.toString()
-                binding.date.setTextColor(binding.root.context.resources.getColor(R.color.orange))
-                binding.detail.setTextColor(binding.root.context.resources.getColor(R.color.black))
-                binding.detail.setTypeface(binding.detail.typeface, Typeface.BOLD)
-            } else {
-                binding.nbUnread.visibility = View.INVISIBLE
-                binding.date.setTextColor(binding.root.context.resources.getColor(R.color.dark_grey_opacity_40))
-                binding.detail.setTextColor(binding.root.context.resources.getColor(R.color.dark_grey_opacity_40))
-                if (!isLastMessageToday(conversation)) {
+                // === État "lu/non lu" ===
+                if (conversation.hasUnread()) {
+                    binding.nbUnread.visibility = View.VISIBLE
+                    binding.nbUnread.text = conversation.numberUnreadMessages.toString()
+                    binding.date.setTextColor(binding.root.context.resources.getColor(R.color.orange))
+                    binding.detail.setTextColor(binding.root.context.resources.getColor(R.color.black))
                     binding.detail.setTypeface(binding.detail.typeface, Typeface.BOLD)
                 } else {
-                    binding.detail.setTypeface(binding.detail.typeface, Typeface.NORMAL)
+                    binding.nbUnread.visibility = View.INVISIBLE
+                    binding.date.setTextColor(binding.root.context.resources.getColor(R.color.dark_grey_opacity_40))
+                    binding.detail.setTextColor(binding.root.context.resources.getColor(R.color.dark_grey_opacity_40))
+                    if (!isLastMessageToday(conversation)) {
+                        binding.detail.setTypeface(binding.detail.typeface, Typeface.BOLD)
+                    } else {
+                        binding.detail.setTypeface(binding.detail.typeface, Typeface.NORMAL)
+                    }
                 }
-            }
 
-            // === Info de blocage ===
+                } else {
+    binding.date.visibility = View.INVISIBLE
+    binding.dateEvent.visibility = View.INVISIBLE
+    binding.nbUnread.visibility = View.INVISIBLE
+}
+// === Info de blocage ===
             if (conversation.imBlocker()) {
                 binding.detail.text = binding.root.resources.getText(R.string.message_user_blocked_by_me_list)
                 binding.detail.setTextColor(binding.root.resources.getColor(R.color.red))

--- a/app/src/main/java/social/entourage/android/discussions/DiscussionsMainFragment.kt
+++ b/app/src/main/java/social/entourage/android/discussions/DiscussionsMainFragment.kt
@@ -44,6 +44,9 @@ enum class FilterMode {
 
 class DiscussionsMainFragment : Fragment() {
 
+    private val eventsPresenter: social.entourage.android.events.EventsPresenter by lazy { social.entourage.android.events.EventsPresenter() }
+    private val groupPresenter: social.entourage.android.groups.GroupPresenter by lazy { social.entourage.android.groups.GroupPresenter() }
+
     private var _binding: FragmentMessagesBinding? = null
     private val binding get() = _binding!!
     private var isFromDetail = false
@@ -74,11 +77,20 @@ class DiscussionsMainFragment : Fragment() {
         initializeSearchBar()
         initializeRecyclerView()
         handleSwipeRefresh()
+        binding.btnValidate.visibility = View.GONE
+        binding.btnValidate.setOnClickListener {
+            discussionsAdapter.isDeletionMode = false
+            binding.btnValidate.visibility = View.GONE
+        }
 
         discussionsPresenter.getAllMessages.observe(viewLifecycleOwner, ::handleResponseGetDiscussions)
         discussionsPresenter.unreadMessages.observe(requireActivity(), ::updateUnreadCount)
         smallTalkViewModel.smallTalks.observe(viewLifecycleOwner, ::handleResponseGetSmallTalks)
         discussionsPresenter.memberships.observe(viewLifecycleOwner, ::handleResponseGetMemberships)
+        discussionsPresenter.hasUserLeftConversation.observe(viewLifecycleOwner, ::handleConversationLeft)
+        eventsPresenter.hasUserLeftEvent.observe(viewLifecycleOwner, ::handleConversationLeft)
+        groupPresenter.hasUserLeftGroup.observe(viewLifecycleOwner, ::handleConversationLeft)
+        smallTalkViewModel.shouldLeave.observe(viewLifecycleOwner, ::handleConversationLeft)
 
         handleImageViewAnimation()
 
@@ -139,7 +151,16 @@ class DiscussionsMainFragment : Fragment() {
         discussionsAdapter = DiscussionsListAdapter(messagesList).apply {
             setOnItemClickListener(object : DiscussionsListAdapter.OnItemClickListener {
                 override fun onItemClick(position: Int, conversation: Conversation) {
-                    showDetail(position) // Appel existant (compatibilité)
+                    if (discussionsAdapter.isDeletionMode) {
+                        deleteConversation(conversation)
+                    } else {
+                        showDetail(position)
+                    }
+                }
+                override fun onItemLongClick(position: Int, conversation: Conversation): Boolean {
+                    discussionsAdapter.isDeletionMode = true
+                    binding.btnValidate.visibility = View.VISIBLE
+                    return true
                 }
             })
         }
@@ -421,5 +442,26 @@ class DiscussionsMainFragment : Fragment() {
             numberUnreadMessages = m.numberOfUnreadMessages ?: 0,
             memberCount = m.numberOfPeople ?: 0
         )
+    }
+
+    private fun handleConversationLeft(hasLeft: Boolean) {
+        if (hasLeft) {
+            reloadFromStart()
+        }
+    }
+
+    private fun deleteConversation(conversation: Conversation) {
+        val position = messagesList.indexOf(conversation)
+        if (position != -1) {
+            messagesList.removeAt(position)
+            discussionsAdapter.notifyItemRemoved(position)
+        }
+        val id = conversation.id ?: return
+        when (conversation.type) {
+            "small_talk" -> smallTalkViewModel.leaveSmallTalk(id.toString())
+            "outing" -> eventsPresenter.leaveEvent(id)
+            "private", "group" -> discussionsPresenter.leaveConverstion(id)
+            else -> discussionsPresenter.leaveConverstion(id)
+        }
     }
 }

--- a/app/src/main/java/social/entourage/android/discussions/SettingsDiscussionModalFragment.kt
+++ b/app/src/main/java/social/entourage/android/discussions/SettingsDiscussionModalFragment.kt
@@ -113,6 +113,9 @@ class SettingsDiscussionModalFragment : BottomSheetDialogFragment() {
         binding.quit.profileSettingsItemLayout.isVisible = !mustHideQuit
         binding.quit.profileSettingsItemArrow.isVisible  = !mustHideQuit
         if (!mustHideQuit) binding.quit.profileSettingsItemLabel.text = getString(R.string.discussion_settings_quit)
+
+        binding.delete.profileSettingsItemLayout.isVisible = isOneToOne
+        binding.delete.profileSettingsItemLabel.text = getString(R.string.delete_conversation)
     }
 
     /* ─────────────────────────── Observers ─────────────────────────── */
@@ -193,6 +196,19 @@ class SettingsDiscussionModalFragment : BottomSheetDialogFragment() {
                 } else {
                     conversationId?.let { discussionPresenter.leaveConverstion(it) }
                 }
+            }
+        }
+
+
+        /* ▶️ Supprimer la conversation (1-1) */
+        binding.delete.profileSettingsItemLayout.setOnClickListener {
+            CustomAlertDialog.showWithCancelFirst(
+                requireContext(),
+                getString(R.string.delete_conversation),
+                getString(R.string.delete_conversation_dialog_content),
+                getString(R.string.delete)
+            ) {
+                conversationId?.let { discussionPresenter.leaveConverstion(it) }
             }
         }
 

--- a/app/src/main/res/layout/fragment_messages.xml
+++ b/app/src/main/res/layout/fragment_messages.xml
@@ -45,6 +45,20 @@
                     android:visibility="gone"
                     />
 
+                <Button
+                    android:id="@+id/btn_validate"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end|top"
+                    android:layout_marginTop="15dp"
+                    android:layout_marginEnd="16dp"
+                    android:backgroundTint="@color/orange"
+                    android:textColor="@color/white"
+                    android:text="@string/validate"
+                    android:visibility="gone"
+                    />
+
+
                 <androidx.appcompat.widget.Toolbar
                     android:id="@+id/toolbar"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/layout_conversation_home_item.xml
+++ b/app/src/main/res/layout/layout_conversation_home_item.xml
@@ -125,6 +125,17 @@
                 app:layout_constraintTop_toBottomOf="@+id/role"
                 tools:text="1" />
 
+
+            <ImageView
+                android:id="@+id/icon_delete"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@drawable/new_delete"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/new_fragment_settings_discussion_modal.xml
+++ b/app/src/main/res/layout/new_fragment_settings_discussion_modal.xml
@@ -185,6 +185,16 @@
                     android:layout_marginStart="25dp"
                     android:layout_marginEnd="25dp"
                     app:icon='@{@drawable/new_sign_out}' />
+
+                <include
+                    android:id="@+id/delete"
+                    layout="@layout/layout_settings_item"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="25dp"
+                    android:layout_marginEnd="25dp"
+                    android:visibility="gone"
+                    app:icon='@{@drawable/new_delete}' />
             </LinearLayout>
         </androidx.core.widget.NestedScrollView>
     </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,6 +137,9 @@
 
     <string name="delete_account_dialog_title">Suppression du compte</string>
     <string name="delete_account_dialog_content">Souhaitez-vous supprimer votre compte ?</string>
+    <string name="delete_conversation">Supprimer la conversation</string>
+    <string name="delete_conversation_dialog_content">Êtes-vous sûr de vouloir supprimer cette conversation ?</string>
+
 
     <string name="unsubscribe_title">Voulez-vous vous désabonner ?</string>
     <string name="unsubscribe_content">En vous désabonnant, vous ne recevrez plus les notifications, nouvelles, et les nouveaux événements de cette association </string>


### PR DESCRIPTION
Added the capability to delete all types of conversations securely from the Android client. This involves a new long-click deletion UX pattern within the main conversation list that displays explicit trash icons. For private 1-1 conversations, an explicit parameter was added to delete it similarly to 1-n, groups, and events.

---
*PR created automatically by Jules for task [154247935624551558](https://jules.google.com/task/154247935624551558) started by @clemPerrousset*