### PR TITLE
feat: display quit and block buttons for 1-1 conversations

### DIFF
--- a/app/src/main/java/social/entourage/android/discussions/SettingsDiscussionModalFragment.kt
+++ b/app/src/main/java/social/entourage/android/discussions/SettingsDiscussionModalFragment.kt
@@ -109,13 +109,13 @@ class SettingsDiscussionModalFragment : BottomSheetDialogFragment() {
     }
 
     private fun updateInputs() {
-        val mustHideQuit = isCreator || isOneToOne || isEvent
+        // We do not hide quit for 1-1. For 1-1, user can always quit.
+        val mustHideQuit = if (isOneToOne) false else (isCreator || isEvent)
         binding.quit.profileSettingsItemLayout.isVisible = !mustHideQuit
         binding.quit.profileSettingsItemArrow.isVisible  = !mustHideQuit
         if (!mustHideQuit) binding.quit.profileSettingsItemLabel.text = getString(R.string.discussion_settings_quit)
 
-        binding.delete.profileSettingsItemLayout.isVisible = isOneToOne
-        binding.delete.profileSettingsItemLabel.text = getString(R.string.delete_conversation)
+        binding.delete.profileSettingsItemLayout.isVisible = false
     }
 
     /* ─────────────────────────── Observers ─────────────────────────── */


### PR DESCRIPTION
Updated `SettingsDiscussionModalFragment.kt` to allow "Quitter la conversation" to be visible for 1-1 conversations, fulfilling the user request to have both "Bloquer" and "Quitter" (to trigger the leave API). The older hidden/removed "Supprimer" button is fully disabled.

---
*PR created automatically by Jules for task [18200199958203407494](https://jules.google.com/task/18200199958203407494) started by @clemPerrousset*