### PR TITLE
Restore country list for authentication

### DIFF
--- a/app/src/main/java/social/entourage/android/tools/view/countrycodepicker/CountryLightList.kt
+++ b/app/src/main/java/social/entourage/android/tools/view/countrycodepicker/CountryLightList.kt
@@ -36,8 +36,6 @@ internal object CountryLightList {
                 context.getString(R.string.country_belgium_number),
                 context.getString(R.string.country_belgium_name),context.getString(R.string.country_belgium_flag))
         )
-        // Les autres pays sont cachés pour le moment à la demande de l'utilisateur
-        /*
         newCountries.add(
             Country(context.getString(R.string.country_guadeloupe_code),
                 context.getString(R.string.country_guadeloupe_number),
@@ -59,7 +57,6 @@ internal object CountryLightList {
                 context.getString(R.string.country_morocco_name),
                 context.getString(R.string.country_morocco_flag))
         )
-        */
         newCountries.sortWith { o1: Country, o2: Country -> o1.name.compareTo(o2.name) }
         countries = newCountries
         return newCountries


### PR DESCRIPTION
Uncommented Guadeloupe, Martinique, Reunion, and Morocco from the list in `CountryLightList.kt` so users can select them during registration and login.

---
*PR created automatically by Jules for task [12468563699956094348](https://jules.google.com/task/12468563699956094348) started by @clemPerrousset*