### PR TITLE
Allow event members to self-check-in

### DIFF
--- a/app/src/main/java/social/entourage/android/groups/details/members/MembersListAdapter.kt
+++ b/app/src/main/java/social/entourage/android/groups/details/members/MembersListAdapter.kt
@@ -62,7 +62,9 @@ class MembersListAdapter(
 
         // -------- Checkbox participation (visibilité + état + listener) --------
         val isMe = EntourageApplication.get().me()?.id == item.userId
-        if (HomeFragment.signablePermission && ActionSheetFragment.isSignable && !MembersActivity.isFromReact) {
+        val canCheckIn = HomeFragment.signablePermission && ActionSheetFragment.isSignable
+
+        if ((canCheckIn || isMe) && !MembersActivity.isFromReact) {
 
             b.checkboxConfirmation.visibility = View.VISIBLE
             // état actuel : participe si participateAt ou confirmedAt non null


### PR DESCRIPTION
- Changed the visibility condition for `checkboxConfirmation` in `MembersListAdapter.onBindViewHolder`.
- Added a `canCheckIn` boolean to evaluate overarching organizer permissions.
- Render the check-in checkbox if `canCheckIn` is true, or if `isMe` is true.

---
*PR created automatically by Jules for task [4325706793551902038](https://jules.google.com/task/4325706793551902038) started by @clemPerrousset*