### PR TITLE
Update Reunion display name to "La Réunion"

### DIFF
--- a/app/src/main/res/values-any/strings.xml
+++ b/app/src/main/res/values-any/strings.xml
@@ -1176,7 +1176,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="country_qatar_name">Qatar</string>
     <string name="country_qatar_code">qa</string>
 
-    <string name="country_reunion_name">Réunion</string>
+    <string name="country_reunion_name">La Réunion</string>
     <string name="country_reunion_code">re</string>
 
     <string name="country_romania_name">Roumanie</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1187,7 +1187,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="country_qatar_name">Qatar</string>
     <string name="country_qatar_code">qa</string>
 
-    <string name="country_reunion_name">Réunion</string>
+    <string name="country_reunion_name">La Réunion</string>
     <string name="country_reunion_code">re</string>
 
     <string name="country_romania_name">Roumanie</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1357,7 +1357,7 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="country_qatar_code">qa</string>
     <string name="country_qatar_number" translatable="false">974</string>
 
-    <string name="country_reunion_name">Réunion</string>
+    <string name="country_reunion_name">La Réunion</string>
     <string name="country_reunion_code">re</string>
     <string name="country_reunion_number" translatable="false">262</string>
     <string name="country_reunion_flag" translatable="false">🇷🇪</string>


### PR DESCRIPTION
Updated the display name for Reunion in the registration Country Code Picker from "Réunion" to "La Réunion". This applies to the default (`values`), generic (`values-any`), and French (`values-fr`) string resources. No functional changes were made; the dialing code (+262) and flag remain the same.

---
*PR created automatically by Jules for task [1417292771196600644](https://jules.google.com/task/1417292771196600644) started by @clemPerrousset*