### PR TITLE
UI: Remove bottom padding from unsubscribed participants block

### DIFF
--- a/app/src/main/res/layout/new_fragment_members.xml
+++ b/app/src/main/res/layout/new_fragment_members.xml
@@ -157,7 +157,6 @@
         android:layout_alignParentBottom="true"
         android:background="@color/white"
         android:orientation="vertical"
-        android:paddingBottom="90dp"
         android:visibility="gone">
 
         <TextView


### PR DESCRIPTION
Removed the 90dp bottom padding from `layout_unsubscribed_participants` in `new_fragment_members.xml` so that the extra participants block (riverains/isolés) touches the bottom of the screen.

---
*PR created automatically by Jules for task [17435512422459356994](https://jules.google.com/task/17435512422459356994) started by @clemPerrousset*