### PR TITLE
feat: image zoom enhancements (download & back arrow)

### DIFF
--- a/add_strings.sh
+++ b/add_strings.sh
@@ -1,0 +1,5 @@
+sed -i '/<\/resources>/i \
+    <string name="download_image_title">Téléchargement de la photo</string>\
+    <string name="download_image_description">Téléchargement en cours...</string>\
+    <string name="download_started">Téléchargement lancé</string>\
+    <string name="download_error">Erreur lors du téléchargement</string>' app/src/main/res/values/strings.xml

--- a/add_strings_en.sh
+++ b/add_strings_en.sh
@@ -1,0 +1,7 @@
+if [ -f "app/src/main/res/values-en/strings.xml" ]; then
+sed -i '/<\/resources>/i \
+    <string name="download_image_title">Downloading photo</string>\
+    <string name="download_image_description">Downloading...</string>\
+    <string name="download_started">Download started</string>\
+    <string name="download_error">Error during download</string>' app/src/main/res/values-en/strings.xml
+fi

--- a/app/src/main/res/drawable/ic_download.xml
+++ b/app/src/main/res/drawable/ic_download.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M19,9h-4V3H9v6H5l7,7 7,-7zM5,18v2h14v-2H5z"/>
+</vector>

--- a/app/src/main/res/layout/activity_image_zoom.xml
+++ b/app/src/main/res/layout/activity_image_zoom.xml
@@ -11,17 +11,28 @@
         android:layout_height="match_parent"
         android:scaleType="fitCenter" />
 
-
     <ImageView
-        android:layout_width="30dp"
-        android:layout_height="30dp"
+        android:layout_width="34dp"
+        android:layout_height="34dp"
         android:id="@+id/btn_quit_photo"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:src="@drawable/icon_cross"
+        android:src="@drawable/ic_arrow_left_black"
         android:background="@drawable/bg_beige_round_15"
         android:padding="8dp"
+        android:layout_gravity="start"
+        android:layout_marginTop="40dp"
+        android:layout_marginStart="20dp"
+        app:tint="@color/black" />
+
+    <ImageView
+        android:layout_width="34dp"
+        android:layout_height="34dp"
+        android:id="@+id/btn_download_photo"
+        android:src="@drawable/ic_download"
+        android:background="@drawable/bg_beige_round_15"
+        android:padding="6dp"
         android:layout_gravity="end"
         android:layout_marginTop="40dp"
-        android:layout_marginEnd="20dp"/>
+        android:layout_marginEnd="20dp"
+        app:tint="@color/black" />
+
 </FrameLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1871,4 +1871,8 @@
     <string name="welcome_webinar_list_subtitle">Prenez en main l\'application et posez toutes vos questions à l\'équipe — en petit groupe, en 45 minutes en visio.</string>
     <string name="welcome_papotages_list_title">Papotages solidaires</string>
     <string name="welcome_papotages_list_subtitle">Discussions libres en sous-groupes de 2 à 3 personnes, animées par un bénévole formé ou un membre de l\'équipe. Vous restez le temps que vous voulez. Tous les mardis à 18h.</string>
+    <string name="download_image_title">Downloading photo</string>
+    <string name="download_image_description">Downloading...</string>
+    <string name="download_started">Download started</string>
+    <string name="download_error">Error during download</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3287,4 +3287,8 @@ Ils liront ce message dès qu’ils rejoindront le groupe.</string>
     <string name="event_settings_see_photos">Voir les photos</string>
     <string name="discussion_de_groupe">Discussion de groupe</string>
     <string name="echanger_avec_participants">Échanger avec les participants</string>
+    <string name="download_image_title">Téléchargement de la photo</string>
+    <string name="download_image_description">Téléchargement en cours...</string>
+    <string name="download_started">Téléchargement lancé</string>
+    <string name="download_error">Erreur lors du téléchargement</string>
 <string name="ajouter_des_participants">Ajouter des participants</string><string name="question_isoles">Combien de personnes isolées supplémentaires ont rejoint l\'événement ?</string><string name="question_riverains">Combien de riverains supplémentaires ont rejoint l\'événement ?</string><string name="question_femmes_isolees">Parmi ces %1$d personnes isolées, combien sont des femmes ?</string><string name="participants_ajoutes_sur_place">PARTICIPANTS AJOUTÉS SUR PLACE</string><string name="personnes_isolees">%1$d personnes isolées</string><string name="personne_isolee">%1$d personne isolée</string><string name="riverains">%1$d riverains</string><string name="riverain">%1$d riverain</string><string name="femmes_isolees">%1$d femmes isolées</string><string name="femme_isolee">%1$d femme isolée</string><string name="ajoutes_sur_place">Ajoutés sur place</string><string name="ajoute_sur_place">Ajouté sur place</string></resources>

--- a/update_activity.sh
+++ b/update_activity.sh
@@ -1,3 +1,4 @@
+cat << 'INNER_EOF' > app/src/main/java/social/entourage/android/comment/ImageZoomActivity.kt
 package social.entourage.android.comment
 
 import android.app.DownloadManager
@@ -66,3 +67,4 @@ class ImageZoomActivity : BaseActivity() {
         }
     }
 }
+INNER_EOF


### PR DESCRIPTION
Adds the ability to download an image from the full screen image zoom view into the user's Downloads directory and replaces the top-right close cross with a proper back arrow (top left) and download icon (top right).

---
*PR created automatically by Jules for task [883291066702498678](https://jules.google.com/task/883291066702498678) started by @clemPerrousset*