### PR TITLE
Fix UI clipping of the 'Voir' button in active small talks

### DIFF
--- a/app/src/main/res/layout/item_home_small_talk_active.xml
+++ b/app/src/main/res/layout/item_home_small_talk_active.xml
@@ -6,6 +6,8 @@
     android:layout_marginTop="15dp"
     android:layout_marginHorizontal="5dp"
     android:background="@drawable/background_organizer"
+    android:clipToPadding="false"
+    android:clipChildren="false"
     android:padding="16dp">
 
     <TextView
@@ -91,6 +93,9 @@
         android:backgroundTint="@color/orange"
         app:cornerRadius="32dp"
         android:fontFamily="@font/quicksand_bold"
+        android:insetTop="0dp"
+        android:insetBottom="0dp"
+        android:minHeight="40dp"
         android:paddingVertical="10dp"
         android:paddingHorizontal="16dp"
         android:text="Voir"


### PR DESCRIPTION
The orange "Voir" button in the active small talk cell (`item_home_small_talk_active.xml`) was being clipped at the top. This happens because `MaterialButton` has default vertical insets, causing its bounds to expand beyond its visible background. When these bounds reached the parent container's padding area, the visible top edge was cut off to a flat square edge instead of its rounded shape.

To fix this:
- Removed `insetTop` and `insetBottom` from the `MaterialButton` and set `minHeight="40dp"`.
- Set `clipToPadding="false"` and `clipChildren="false"` on the parent `ConstraintLayout` to further prevent clipping.

---
*PR created automatically by Jules for task [14484097182512414487](https://jules.google.com/task/14484097182512414487) started by @clemPerrousset*