### PR TITLE
Add possibility to upload custom photo to events

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -242,6 +242,7 @@ dependencies {
     implementation(libs.material.datetime.picker)
     implementation(libs.fab)
     implementation(libs.cropme)
+    implementation(libs.ucrop)
     implementation(libs.maps.utils.ktx)
     implementation(libs.material)
     implementation(libs.glide)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -358,6 +358,10 @@
          <uses-library
              android:name="android.test.runner"
              android:required="false" />
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
      </application>
 
  </manifest>

--- a/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
+++ b/app/src/main/java/social/entourage/android/api/request/EventsRequest.kt
@@ -179,6 +179,11 @@ interface EventsRequest {
         @Body params: RequestContent
     ): Call<PrepareAddPostResponse>
 
+    @POST("outings/presigned_upload")
+    fun prepareImageUpload(
+        @Body params: social.entourage.android.events.create.PrepareEventImageUploadRepository.Request
+    ): Call<social.entourage.android.events.create.PrepareEventImageUploadRepository.Response>
+
     @GET("outings/{event_id}/chat_messages/{post_id}/comments")
     fun getPostComments(
         @Path("event_id") eventId: Int,

--- a/app/src/main/java/social/entourage/android/events/create/CreateEvent.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEvent.kt
@@ -89,6 +89,9 @@ data class CreateEvent(
     @SerializedName("entourage_image_id")
     var entourageImageId: Int? = null,
 
+    @SerializedName("image_url")
+    var imageUrl: String? = null,
+
     @SerializedName("neighborhood_ids")
     var neighborhoodIds: MutableList<Int> = mutableListOf(),
 
@@ -122,6 +125,10 @@ data class CreateEvent(
         entourageImageId = value
     }
 
+    fun imageUrl(value: String?) = apply {
+        imageUrl = value
+    }
+
     fun description(value: String) = apply {
         description = value
     }
@@ -143,7 +150,7 @@ data class CreateEvent(
     }
 
     override fun toString(): String {
-        return "CreateEvent(metadata=$metadata, description=$description, title=$title, eventUrl=$eventUrl, online=$online, latitude=$latitude, longitude=$longitude, otherInterest=$otherInterest, interests=$interests, entourageImageId=$entourageImageId, neighborhoodIds=$neighborhoodIds, recurrence=$recurrence)"
+        return "CreateEvent(metadata=$metadata, description=$description, title=$title, eventUrl=$eventUrl, online=$online, latitude=$latitude, longitude=$longitude, otherInterest=$otherInterest, interests=$interests, entourageImageId=$entourageImageId, imageUrl=$imageUrl, neighborhoodIds=$neighborhoodIds, recurrence=$recurrence)"
     }
 
 }

--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepOneFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepOneFragment.kt
@@ -9,10 +9,16 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import android.widget.TextView
+import android.content.Intent
+import android.app.Activity
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResultListener
 import com.bumptech.glide.Glide
+import com.yalantis.ucrop.UCrop
+import java.io.File
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
+import android.widget.Toast
 import com.bumptech.glide.load.resource.bitmap.RoundedCorners
 import social.entourage.android.R
 import social.entourage.android.api.model.Image
@@ -23,17 +29,78 @@ import social.entourage.android.tools.log.AnalyticsEvents
 import social.entourage.android.tools.utils.Const
 import social.entourage.android.tools.utils.px
 
-class CreateEventStepOneFragment : Fragment() {
+class CreateEventStepOneFragment : Fragment(), EventImageUploadView {
 
     private var _binding: NewFragmentCreateEventStepOneBinding? = null
     val binding: NewFragmentCreateEventStepOneBinding get() = _binding!!
     private var selectedImage: Image? = null
+    private var uploadedImageFile: File? = null
+    private lateinit var uploadPresenter: EventImageUploadPresenter
+    private var isUploading = false
+
+    private val getContent = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        uri?.let {
+            val destinationUri = Uri.fromFile(File(requireContext().cacheDir, "cropped_event_image.jpg"))
+            val options = UCrop.Options()
+            options.setToolbarTitle(getString(R.string.group_choose_photo))
+            options.setCircleDimmedLayer(false)
+            UCrop.of(it, destinationUri)
+                .withAspectRatio(16f, 9f)
+                .withOptions(options)
+                .start(requireContext(), this)
+        }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (resultCode == Activity.RESULT_OK && requestCode == UCrop.REQUEST_CROP) {
+            val resultUri = UCrop.getOutput(data!!)
+            resultUri?.let { uri ->
+                val file = File(uri.path!!)
+                uploadedImageFile = file
+                selectedImage = null // Clear previously selected default image
+                CommunicationHandler.event.entourageImageId(null)
+
+                binding.layout.addPhotoLayout.visibility = View.GONE
+                binding.layout.addPhoto.visibility = View.VISIBLE
+                Glide.with(requireActivity())
+                    .load(uri)
+                    .transform(CenterCrop(), RoundedCorners(Const.ROUNDED_CORNERS_IMAGES.px))
+                    .into(binding.layout.addPhoto)
+
+                CommunicationHandler.isButtonClickable.value =
+                    isGroupNameValid() && isGroupDescriptionValid() && isImageValid()
+
+                isUploading = true
+                CommunicationHandler.isButtonClickable.value = false
+                Toast.makeText(requireContext(), "Upload de l'image en cours...", Toast.LENGTH_SHORT).show()
+                uploadPresenter.uploadPhoto(file)
+            }
+        } else if (resultCode == UCrop.RESULT_ERROR) {
+            val cropError = UCrop.getError(data!!)
+            cropError?.printStackTrace()
+        }
+    }
+
+    override fun onUploadError() {
+        isUploading = false
+        Toast.makeText(requireContext(), "Erreur lors du chargement de l'image", Toast.LENGTH_SHORT).show()
+        CommunicationHandler.isButtonClickable.value = false
+    }
+
+    override fun onUploadSuccess(uploadKey: String) {
+        isUploading = false
+        CommunicationHandler.event.imageUrl(uploadKey)
+        CommunicationHandler.isButtonClickable.value =
+            isGroupNameValid() && isGroupDescriptionValid() && isImageValid()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         _binding = NewFragmentCreateEventStepOneBinding.inflate(inflater, container, false)
+        uploadPresenter = EventImageUploadPresenter(this, EventImageUploadRepository())
         return binding.root
     }
 
@@ -88,20 +155,27 @@ class CreateEventStepOneFragment : Fragment() {
 
     private fun onFragmentResult() {
         setFragmentResultListener(Const.REQUEST_KEY_CHOOSE_PHOTO) { _, bundle ->
-            selectedImage = bundle.getParcelable(Const.CHOOSE_PHOTO_PATH)
-            CommunicationHandler.isButtonClickable.value = isImageValid()
-            CommunicationHandler.event.entourageImageId(selectedImage?.id)
-            val imageUrl =
-                if (selectedImage?.portraitUrl != null) selectedImage?.portraitUrl else selectedImage?.landscapeUrl
-            imageUrl?.let { url ->
-                CommunicationHandler.isButtonClickable.value =
-                    isGroupNameValid() && isGroupDescriptionValid() && isImageValid()
-                binding.layout.addPhotoLayout.visibility = View.GONE
-                binding.layout.addPhoto.visibility = View.VISIBLE
-                Glide.with(requireActivity())
-                    .load(Uri.parse(url))
-                    .transform(CenterCrop(), RoundedCorners(Const.ROUNDED_CORNERS_IMAGES.px))
-                    .into(binding.layout.addPhoto)
+            val isAddPhoto = bundle.getBoolean("is_add_photo", false)
+            if (isAddPhoto) {
+                getContent.launch("image/*")
+            } else {
+                selectedImage = bundle.getParcelable(Const.CHOOSE_PHOTO_PATH)
+                uploadedImageFile = null
+                CommunicationHandler.isButtonClickable.value = isImageValid()
+                CommunicationHandler.event.entourageImageId(selectedImage?.id)
+                CommunicationHandler.event.imageUrl(null)
+                val imageUrl =
+                    if (selectedImage?.portraitUrl != null) selectedImage?.portraitUrl else selectedImage?.landscapeUrl
+                imageUrl?.let { url ->
+                    CommunicationHandler.isButtonClickable.value =
+                        isGroupNameValid() && isGroupDescriptionValid() && isImageValid()
+                    binding.layout.addPhotoLayout.visibility = View.GONE
+                    binding.layout.addPhoto.visibility = View.VISIBLE
+                    Glide.with(requireActivity())
+                        .load(Uri.parse(url))
+                        .transform(CenterCrop(), RoundedCorners(Const.ROUNDED_CORNERS_IMAGES.px))
+                        .into(binding.layout.addPhoto)
+                }
             }
         }
     }
@@ -132,7 +206,7 @@ class CreateEventStepOneFragment : Fragment() {
     }
 
     fun isImageValid(): Boolean {
-        return selectedImage != null
+        return (selectedImage != null || uploadedImageFile != null) && !isUploading
     }
 
     fun canExitEventCreation(): Boolean {

--- a/app/src/main/java/social/entourage/android/events/create/EventImageUploadPresenter.kt
+++ b/app/src/main/java/social/entourage/android/events/create/EventImageUploadPresenter.kt
@@ -1,0 +1,48 @@
+package social.entourage.android.events.create
+
+import android.os.Handler
+import android.os.Looper
+import timber.log.Timber
+import java.io.File
+
+interface EventImageUploadView {
+    fun onUploadError()
+    fun onUploadSuccess(uploadKey: String)
+}
+
+class EventImageUploadPresenter(
+    private val view: EventImageUploadView,
+    private val uploadRepository: EventImageUploadRepository
+) : PrepareEventImageUploadRepository.Callback, EventImageUploadRepository.Callback {
+
+    private val prepareUploadRepository = PrepareEventImageUploadRepository(this)
+    private var file: File? = null
+    private var uploadKey: String? = null
+
+    init {
+        uploadRepository.setCallback(this)
+    }
+
+    fun uploadPhoto(file: File) {
+        this.file = file
+        prepareUploadRepository.prepareUpload()
+    }
+
+    override fun onPrepareUploadSuccess(uploadKey: String, presignedUrl: String) {
+        this.uploadKey = uploadKey
+        file?.let { uploadRepository.uploadFile(it, presignedUrl) }
+    }
+
+    override fun onUploadSuccess() {
+        if (file?.delete() != true) {
+            Timber.d("Failed to delete the temporary photo file")
+        }
+        uploadKey?.let {
+            Handler(Looper.getMainLooper()).post { view.onUploadSuccess(it) }
+        }
+    }
+
+    override fun onRepositoryError() {
+        Handler(Looper.getMainLooper()).post { view.onUploadError() }
+    }
+}

--- a/app/src/main/java/social/entourage/android/events/create/EventImageUploadRepository.kt
+++ b/app/src/main/java/social/entourage/android/events/create/EventImageUploadRepository.kt
@@ -1,0 +1,44 @@
+package social.entourage.android.events.create
+
+import okhttp3.*
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.RequestBody.Companion.asRequestBody
+import social.entourage.android.EntourageApplication
+import java.io.File
+import java.io.IOException
+
+class EventImageUploadRepository : Callback {
+    private val client: OkHttpClient
+        get() = EntourageApplication.get().apiModule.okHttpClient
+    private var callback: Callback? = null
+
+    fun setCallback(callback: Callback) {
+        this.callback = callback
+    }
+
+    fun uploadFile(file: File, presignedUrl: String) {
+        val requestBody = file.asRequestBody("image/jpeg".toMediaTypeOrNull())
+        val request = Request.Builder()
+                .url(presignedUrl)
+                .put(requestBody)
+                .build()
+        client.newCall(request).enqueue(this)
+    }
+
+    override fun onFailure(call: Call, e: IOException) {
+        callback?.onRepositoryError()
+    }
+
+    override fun onResponse(call: Call, response: Response) {
+        if (response.isSuccessful) {
+            callback?.onUploadSuccess()
+        } else {
+            callback?.onRepositoryError()
+        }
+    }
+
+    interface Callback {
+        fun onUploadSuccess()
+        fun onRepositoryError()
+    }
+}

--- a/app/src/main/java/social/entourage/android/events/create/PrepareEventImageUploadRepository.kt
+++ b/app/src/main/java/social/entourage/android/events/create/PrepareEventImageUploadRepository.kt
@@ -1,0 +1,44 @@
+package social.entourage.android.events.create
+
+import com.google.gson.annotations.SerializedName
+import retrofit2.Call
+import retrofit2.Callback
+import social.entourage.android.EntourageApplication
+
+class PrepareEventImageUploadRepository(private var callback: Callback?) :
+    Callback<PrepareEventImageUploadRepository.Response> {
+
+    fun prepareUpload() {
+        val request = Request("image/jpeg")
+        EntourageApplication.get().apiModule.eventsRequest.prepareImageUpload(request).enqueue(this)
+    }
+
+    override fun onResponse(call: Call<Response>, response: retrofit2.Response<Response>) {
+        if (response.isSuccessful) {
+            response.body()?.let {
+                callback?.onPrepareUploadSuccess(it.uploadKey, it.presignedUrl)
+                return
+            }
+        }
+        callback?.onRepositoryError()
+    }
+
+    override fun onFailure(call: Call<Response>, t: Throwable) {
+        callback?.onRepositoryError()
+    }
+
+    interface Callback {
+        fun onPrepareUploadSuccess(uploadKey: String, presignedUrl: String)
+        fun onRepositoryError()
+    }
+
+    inner class Request internal constructor(
+        @field:SerializedName("content_type")
+        private val contentType: String
+    )
+
+    inner class Response(
+        @field:SerializedName("upload_key") var uploadKey: String,
+        @field:SerializedName("presigned_url") val presignedUrl: String
+    )
+}

--- a/app/src/main/java/social/entourage/android/groups/choosePhoto/ChooseGalleryPhotoModalFragment.kt
+++ b/app/src/main/java/social/entourage/android/groups/choosePhoto/ChooseGalleryPhotoModalFragment.kt
@@ -13,12 +13,14 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import social.entourage.android.EntourageApplication
 import social.entourage.android.R
 import social.entourage.android.api.MetaDataRepository
 import social.entourage.android.api.model.Image
 import social.entourage.android.databinding.NewFragmentCreateGroupChoosePhotoModalBinding
 import social.entourage.android.tools.log.AnalyticsEvents
 import social.entourage.android.tools.utils.Const
+import android.content.Intent
 
 private const val SPAN_COUNT = 3
 
@@ -102,8 +104,23 @@ class ChooseGalleryPhotoModalFragment : BottomSheetDialogFragment() {
         imagesType = arguments?.getSerializable(Const.IMAGES_TYPE) as ImagesType
     }
 
+    private fun hasValidRole(): Boolean {
+        val userRoles = EntourageApplication.get().me()?.roles ?: return false
+        return userRoles.contains("Association") ||
+               userRoles.contains("Équipe Entourage") ||
+               userRoles.contains("Animateur Entourage")
+    }
+
     private fun initializeInterests() {
-        choosePhotoAdapter = ChoosePhotoAdapter(photosList, imagesType == ImagesType.EVENTS)
+        val showAddPhoto = hasValidRole() && imagesType == ImagesType.EVENTS
+        choosePhotoAdapter = ChoosePhotoAdapter(photosList, imagesType == ImagesType.EVENTS, showAddPhoto) {
+            setFragmentResult(
+                Const.REQUEST_KEY_CHOOSE_PHOTO,
+                bundleOf("is_add_photo" to true)
+            )
+            dismiss()
+        }
+
         binding.recyclerView.apply {
             layoutManager = GridLayoutManager(context, SPAN_COUNT)
             adapter = choosePhotoAdapter
@@ -126,7 +143,7 @@ class ChooseGalleryPhotoModalFragment : BottomSheetDialogFragment() {
             image?.let {
                 setFragmentResult(
                     Const.REQUEST_KEY_CHOOSE_PHOTO,
-                    bundleOf(Const.CHOOSE_PHOTO_PATH to it)
+                    bundleOf(Const.CHOOSE_PHOTO_PATH to it, "is_add_photo" to false)
                 )
                 dismiss()
             }

--- a/app/src/main/java/social/entourage/android/groups/choosePhoto/ChoosePhotoAdapter.kt
+++ b/app/src/main/java/social/entourage/android/groups/choosePhoto/ChoosePhotoAdapter.kt
@@ -2,6 +2,7 @@ package social.entourage.android.groups.choosePhoto
 
 import android.net.Uri
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
@@ -11,66 +12,100 @@ import com.bumptech.glide.request.RequestOptions
 import social.entourage.android.R
 import social.entourage.android.api.model.Image
 import social.entourage.android.databinding.NewPhotoItemBinding
+import social.entourage.android.databinding.NewPhotoAddItemBinding
 import social.entourage.android.tools.utils.Const
 import social.entourage.android.tools.utils.px
 
 class ChoosePhotoAdapter(
-    var photosList: List<Image>, var isEvent:Boolean
-) : RecyclerView.Adapter<ChoosePhotoAdapter.ViewHolder>() {
+    var photosList: List<Image>,
+    var isEvent: Boolean,
+    var showAddPhotoItem: Boolean = false,
+    var onAddPhotoClick: (() -> Unit)? = null
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var checkedPosition = -1
 
-    inner class ViewHolder(val binding: NewPhotoItemBinding) :
-        RecyclerView.ViewHolder(binding.root)
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val binding = NewPhotoItemBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            false
-        )
-
-        return ViewHolder(binding)
+    companion object {
+        const val TYPE_ADD = 0
+        const val TYPE_PHOTO = 1
     }
 
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        with(holder) {
-            with(photosList[position]) {
-                var imageUrl:String?
+    override fun getItemViewType(position: Int): Int {
+        if (showAddPhotoItem && position == 0) {
+            return TYPE_ADD
+        }
+        return TYPE_PHOTO
+    }
 
-                if (isEvent) {
-                    imageUrl = if (this.portraitUrl != null) this.portraitUrl else this.landscapeUrl
-                }
-                else {
-                    imageUrl = this.imageUrl
-                }
-                
-                imageUrl?.let {
-                    Glide.with(binding.image.context)
-                        .load(Uri.parse(it))
-                        .apply(RequestOptions().override(90.px, 90.px))
-                        .transform(
-                            CenterCrop(),
-                            RoundedCorners(Const.ROUNDED_CORNERS_IMAGES.px)
-                        )
-                        .placeholder(R.drawable.placeholder_user)
-                        .into(binding.image)
-                }
-                if (photosList[position].isSelected == true) {
-                    checkedPosition = position
-                    binding.image.setBackgroundResource(R.drawable.new_bg_choose_photo_selected)
+    inner class PhotoViewHolder(val binding: NewPhotoItemBinding) :
+        RecyclerView.ViewHolder(binding.root)
 
-                } else
-                    binding.image.setBackgroundResource(0)
+    inner class AddPhotoViewHolder(val binding: NewPhotoAddItemBinding) :
+        RecyclerView.ViewHolder(binding.root)
 
-                binding.image.setOnClickListener {
-                    if (checkedPosition != -1) {
-                        photosList[checkedPosition].isSelected = false
-                        notifyItemChanged(checkedPosition)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return if (viewType == TYPE_ADD) {
+            val binding = NewPhotoAddItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+            AddPhotoViewHolder(binding)
+        } else {
+            val binding = NewPhotoItemBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+            PhotoViewHolder(binding)
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (getItemViewType(position) == TYPE_ADD) {
+            (holder as AddPhotoViewHolder).binding.layoutAddPhoto.setOnClickListener {
+                onAddPhotoClick?.invoke()
+            }
+        } else {
+            val photoPosition = if (showAddPhotoItem) position - 1 else position
+            val photoHolder = holder as PhotoViewHolder
+            with(photoHolder) {
+                with(photosList[photoPosition]) {
+                    var imageUrl: String?
+
+                    if (isEvent) {
+                        imageUrl = if (this.portraitUrl != null) this.portraitUrl else this.landscapeUrl
+                    } else {
+                        imageUrl = this.imageUrl
                     }
-                    photosList[position].isSelected = true
-                    checkedPosition = position
-                    notifyItemChanged(position)
+
+                    imageUrl?.let {
+                        Glide.with(binding.image.context)
+                            .load(Uri.parse(it))
+                            .apply(RequestOptions().override(90.px, 90.px))
+                            .transform(
+                                CenterCrop(),
+                                RoundedCorners(Const.ROUNDED_CORNERS_IMAGES.px)
+                            )
+                            .placeholder(R.drawable.placeholder_user)
+                            .into(binding.image)
+                    }
+                    if (photosList[photoPosition].isSelected == true) {
+                        checkedPosition = photoPosition
+                        binding.image.setBackgroundResource(R.drawable.new_bg_choose_photo_selected)
+                    } else {
+                        binding.image.setBackgroundResource(0)
+                    }
+
+                    binding.image.setOnClickListener {
+                        if (checkedPosition != -1) {
+                            photosList[checkedPosition].isSelected = false
+                            notifyItemChanged(if (showAddPhotoItem) checkedPosition + 1 else checkedPosition)
+                        }
+                        photosList[photoPosition].isSelected = true
+                        checkedPosition = photoPosition
+                        notifyItemChanged(position)
+                    }
                 }
             }
         }
@@ -83,6 +118,6 @@ class ChoosePhotoAdapter(
     }
 
     override fun getItemCount(): Int {
-        return photosList.size
+        return if (showAddPhotoItem) photosList.size + 1 else photosList.size
     }
 }

--- a/app/src/main/res/layout/new_photo_add_item.xml
+++ b/app/src/main/res/layout/new_photo_add_item.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/layout_add_photo"
+    android:layout_width="90dp"
+    android:layout_height="90dp"
+    android:layout_margin="2dp"
+    android:background="@drawable/new_bg_choose_photo_group"
+    android:padding="2dp">
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:src="@drawable/new_plus" />
+</FrameLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ play-services-auth-api-phone = "18.3.0"
 espresso-contrib = "3.7.0"
 
 [libraries]
+ucrop = { module = "com.github.yalantis:ucrop", version = "2.2.8" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp-bom" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }


### PR DESCRIPTION
# Goal
Allow authorized users to upload their own images to illustrate events, rather than using predefined ones. The image should be cropped in 16:9 and uploaded securely without adding it to the shared gallery.

# Implementation
- **Adapter Update:** Modified `ChoosePhotoAdapter` to inject an "Add Photo" button at the beginning of the gallery list. Authorized user roles are checked using `hasValidRole()`.
- **UCrop Integration:** Hooked up `UCropActivity` directly via the Android API to seamlessly crop the picked image with a fixed `16:9` ratio, providing a fast native experience.
- **Upload Logic:** Developed `PrepareEventImageUploadRepository` and `EventImageUploadRepository` (based on profile avatars pattern) to fetch an `upload_key` via a presigned URL, and upload the image file to AWS. 
- **Payload update:** Mapped the generated upload key to `imageUrl` in the `CreateEvent` entity, preserving existing capabilities for `entourage_image_id`.

---
*PR created automatically by Jules for task [7335928810997773955](https://jules.google.com/task/7335928810997773955) started by @clemPerrousset*