### PR TITLE
feat: Add deeplink for welcome video on home screen

### DIFF
--- a/app/src/main/java/social/entourage/android/MainActivity.kt
+++ b/app/src/main/java/social/entourage/android/MainActivity.kt
@@ -69,6 +69,7 @@ class MainActivity : BaseSecuredActivity() {
     private lateinit var viewModel: CommunicationHandlerBadgeViewModel
     private val universalLinkManager = UniversalLinkManager(this)
     private var fromDeepLinkGoDiscoverGroup = false
+    private var fromDeepLinkGoWelcomeVideo = false
     private lateinit var updateActivityResultLauncher: ActivityResultLauncher<IntentSenderRequest>
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -117,6 +118,14 @@ class MainActivity : BaseSecuredActivity() {
 
     fun getFromDeepLGoDiscoverGroup(): Boolean {
         return this.fromDeepLinkGoDiscoverGroup
+    }
+
+    fun setGoWelcomeVideoFromDeepL(bool: Boolean) {
+        this.fromDeepLinkGoWelcomeVideo = bool
+    }
+
+    fun getFromDeepLGoWelcomeVideo(): Boolean {
+        return this.fromDeepLinkGoWelcomeVideo
     }
 
     override fun onStart() {
@@ -308,12 +317,20 @@ class MainActivity : BaseSecuredActivity() {
         val goDiscoverGroup = intent.getBooleanExtra("goDiscoverGroup", false)
         val goDiscoverEvent = intent.getBooleanExtra("goDiscoverEvent", false)
         val goBirthday = intent.getBooleanExtra("goBirthday", false)
+        val goWelcomeVideo = intent.getBooleanExtra("goWelcomeVideo", false)
 
 
         if (goBirthday) {
             intent.removeExtra("goBirthday")
             goHome()
             startActivity(Intent(this, BirthdayActivity::class.java))
+            return
+        }
+
+        if (goWelcomeVideo) {
+            intent.removeExtra("goWelcomeVideo")
+            this.setGoWelcomeVideoFromDeepL(true)
+            goHome()
             return
         }
 

--- a/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
+++ b/app/src/main/java/social/entourage/android/deeplinks/UniversalLinkManager.kt
@@ -82,6 +82,13 @@ class UniversalLinkManager(val context:Context):UniversalLinksPresenterCallback 
                 pathSegments.contains("app") && pathSegments.size == 1 -> {
                     (context as? MainActivity)?.goHome()
                 }
+                pathSegments.contains("welcome-video") || (pathSegments.contains("home") && pathSegments.contains("welcome-video")) -> {
+                    val intent = Intent(context, MainActivity::class.java)
+                        .addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+                    intent.putExtra("goWelcomeVideo", true)
+                    context.startActivity(intent)
+                    (context as? Activity)?.overridePendingTransition(R.anim.slide_in_right, R.anim.slide_out_left)
+                }
                 pathSegments.contains("outings") && pathSegments.contains("chat_messages") -> {
                     if (pathSegments.size > 3) {
                         val eventId = pathSegments[2]

--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -247,7 +247,7 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
         }
     }
 
-    private fun showVideoModal() {
+    fun showVideoModal() {
         if (!isAdded) return
         val bottomSheetDialog = BottomSheetDialog(requireContext(), R.style.AppBottomSheetDialogTheme)
         val view = layoutInflater.inflate(R.layout.dialog_welcome_video, null)
@@ -603,6 +603,12 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
         actionsPresenter.getUnreadCount()
         sendUserDiscussionStatus()
         loadSmallTalkItems()
+
+        val mainActivity = requireActivity() as? MainActivity
+        if (mainActivity?.getFromDeepLGoWelcomeVideo() == true) {
+            mainActivity.setGoWelcomeVideoFromDeepL(false)
+            showVideoModal()
+        }
     }
 
     private fun loadSmallTalkItems() {


### PR DESCRIPTION
Implemented a new deep link (`/home/welcome-video`) that seamlessly redirects the user to the Home view and auto-plays the Welcome Video by triggering its corresponding bottom sheet via `showVideoModal()`.

The approach uses Android intents paired with lifecycle `onResume()` checks inside `HomeFragment` to ensure the modal opens precisely when the user lands on the Home view.

---
*PR created automatically by Jules for task [15002740395195068653](https://jules.google.com/task/15002740395195068653) started by @clemPerrousset*