### PR TITLE
Update smalltalk waiting UI with an hourglass vector icon

### DIFF
--- a/app/src/main/res/drawable/bg_circle_light_orange.xml
+++ b/app/src/main/res/drawable/bg_circle_light_orange.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval">
-    <solid android:color="#FFF5ED" />
+    <solid android:color="#FFE8D6" />
 </shape>

--- a/app/src/main/res/drawable/ic_hourglass_small_talk.xml
+++ b/app/src/main/res/drawable/ic_hourglass_small_talk.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/orange">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M6,2v6h0.01L6,8.01 10,12l-4,4l0.01,0.01H6V22h12v-5.99h-0.01L18,16l-4,-4l4,-3.99 -0.01,-0.01H18V2H6zm10,14.5V20H8v-3.5l4,-4 4,4zm-4,-5l-4,-4V4h8v3.5l-4,4z"/>
+</vector>

--- a/app/src/main/res/layout/item_home_small_talk_waiting.xml
+++ b/app/src/main/res/layout/item_home_small_talk_waiting.xml
@@ -11,9 +11,11 @@
 
     <ImageView
         android:id="@+id/iv_home_small_talk_icon_waiting"
-        android:layout_width="40dp"
-        android:layout_height="40dp"
-        android:src="@drawable/ic_home_wait_small_talk"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:padding="12dp"
+        android:background="@drawable/bg_circle_light_orange"
+        android:src="@drawable/ic_hourglass_small_talk"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
Updates the smalltalk "waiting" cell on the Home screen to use an hourglass vector drawable with a circular background, replacing the old imported icon.

---
*PR created automatically by Jules for task [12889934844434394932](https://jules.google.com/task/12889934844434394932) started by @clemPerrousset*