### PR TITLE
fix: Enforce 16:9 aspect ratio for event creation image uploads

### DIFF
--- a/app/src/main/java/social/entourage/android/events/create/CreateEventStepOneFragment.kt
+++ b/app/src/main/java/social/entourage/android/events/create/CreateEventStepOneFragment.kt
@@ -50,8 +50,8 @@ class CreateEventStepOneFragment : Fragment(), EventImageUploadView {
             options.setCircleDimmedLayer(false)
 
             // CORRECTION : Forcer l'affichage des contrôles pour aider l'UI à se redessiner
-            options.setHideBottomControls(false)
-            options.setFreeStyleCropEnabled(true)
+            options.setHideBottomControls(true)
+            options.setFreeStyleCropEnabled(false)
 
             UCrop.of(it, destinationUri)
                 .withAspectRatio(16f, 9f)


### PR DESCRIPTION
This change configures the UCrop library to strictly enforce the 16:9 aspect ratio when a user selects a custom image from their gallery for an event. It hides the bottom controls that allow format changes and disables the free-style cropping option.

---
*PR created automatically by Jules for task [17247778470014727837](https://jules.google.com/task/17247778470014727837) started by @clemPerrousset*