### PR TITLE
feat: Reduce buttons size in image zoom to 25x25dp

### DIFF
--- a/app/src/main/res/layout/activity_image_zoom.xml
+++ b/app/src/main/res/layout/activity_image_zoom.xml
@@ -12,24 +12,24 @@
         android:scaleType="fitCenter" />
 
     <ImageView
-        android:layout_width="48dp"
-        android:layout_height="48dp"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
         android:id="@+id/btn_quit_photo"
         android:src="@drawable/ic_close_black_24dp"
         android:background="@android:color/transparent"
-        android:padding="12dp"
+        android:padding="4dp"
         android:layout_gravity="start"
         android:layout_marginTop="50dp"
         android:layout_marginStart="13dp"
         app:tint="@color/white" />
 
     <ImageView
-        android:layout_width="48dp"
-        android:layout_height="48dp"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
         android:id="@+id/btn_download_photo"
         android:src="@drawable/ic_download"
         android:background="@android:color/transparent"
-        android:padding="12dp"
+        android:padding="4dp"
         android:layout_gravity="end"
         android:layout_marginTop="50dp"
         android:layout_marginEnd="13dp"

--- a/app/src/main/res/layout/fragment_image_viewer.xml
+++ b/app/src/main/res/layout/fragment_image_viewer.xml
@@ -7,8 +7,8 @@
     android:fitsSystemWindows="true">
 
     <ImageButton
-        android:layout_width="40dp"
-        android:layout_height="40dp"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
         android:id="@+id/btn_close"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
@@ -17,7 +17,7 @@
         android:background="@drawable/white_round_imagebutton"
         android:layout_marginEnd="25dp"
         android:layout_marginTop="25dp"
-        android:padding="10dp"
+        android:padding="4dp"
         android:elevation="10dp"/>
     <com.github.chrisbanes.photoview.PhotoView
         android:id="@+id/photo_view"


### PR DESCRIPTION
Limitation de la taille des boutons à 25x25 max dans le zoom photo (conversation et galerie). Ajustement du padding interne.

---
*PR created automatically by Jules for task [1343912614145990226](https://jules.google.com/task/1343912614145990226) started by @clemPerrousset*