### PR TITLE
Fix: Hide launch new conversation button on matching

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomeSmallTalkAdapter.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeSmallTalkAdapter.kt
@@ -162,7 +162,7 @@ class HomeSmallTalkAdapter(
             }
 
             // Launch new button
-            if (item.totalCount < 3) {
+            if (item.totalCount < 3 && item.waitingCount == 0) {
                 binding.tvHomeSmallTalkLaunchNew.visibility = View.VISIBLE
                 binding.tvHomeSmallTalkLaunchNew.text = context.getString(R.string.home_small_talk_launch_new, item.totalCount)
                 binding.tvHomeSmallTalkLaunchNew.setOnClickListener {


### PR DESCRIPTION
This pull request addresses the user's request to restrict launching a new SmallTalk conversation when there is already one in the matching phase. It updates the visibility condition of the `tvHomeSmallTalkLaunchNew` button in the `HomeSmallTalkAdapter` to include `item.waitingCount == 0`, ensuring users must wait for their current matching process to finish before initiating another. It also keeps the existing logic which restricts launching more conversations once the user reaches 3 active conversations.

---
*PR created automatically by Jules for task [12139410962855517431](https://jules.google.com/task/12139410962855517431) started by @clemPerrousset*