### PR TITLE
fix(home): Update small talk card margins and remove section title

### DIFF
--- a/app/src/main/java/social/entourage/android/home/HomeFragment.kt
+++ b/app/src/main/java/social/entourage/android/home/HomeFragment.kt
@@ -638,7 +638,7 @@ class HomeFragment : Fragment(), OnHomeChangeLocationUpdate {
         homeSmallTalkAdapter.submitList(items)
 
         val hasItems = items.isNotEmpty()
-        smallTalkHeaderAdapter.update(getString(R.string.home_title_small_talk), null, hasItems)
+        smallTalkHeaderAdapter.update("", null, false)
     }
 
 

--- a/app/src/main/res/layout/item_home_small_talk_active.xml
+++ b/app/src/main/res/layout/item_home_small_talk_active.xml
@@ -3,9 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="15dp"
-    android:layout_marginStart="10dp"
-    android:layout_marginEnd="10dp"
+    android:layout_marginTop="@dimen/entourage_little_margin_top"
+    android:layout_marginStart="@dimen/entourage_marginstart"
+    android:layout_marginEnd="@dimen/entourage_margin_end"
     android:background="@drawable/background_organizer"
     android:paddingBottom="16dp">
 

--- a/app/src/main/res/layout/item_home_small_talk_match.xml
+++ b/app/src/main/res/layout/item_home_small_talk_match.xml
@@ -3,8 +3,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="15dp"
-    android:layout_marginHorizontal="5dp"
+    android:layout_marginTop="@dimen/entourage_little_margin_top"
+    android:layout_marginStart="@dimen/entourage_marginstart"
+    android:layout_marginEnd="@dimen/entourage_margin_end"
     android:background="@drawable/background_organizer"
     android:padding="16dp">
 

--- a/app/src/main/res/layout/item_home_small_talk_waiting.xml
+++ b/app/src/main/res/layout/item_home_small_talk_waiting.xml
@@ -4,8 +4,9 @@
     android:id="@+id/layout_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="15dp"
-    android:layout_marginHorizontal="5dp"
+    android:layout_marginTop="@dimen/entourage_little_margin_top"
+    android:layout_marginStart="@dimen/entourage_marginstart"
+    android:layout_marginEnd="@dimen/entourage_margin_end"
     android:background="@drawable/background_organizer"
     android:padding="16dp">
 


### PR DESCRIPTION
This pull request removes the "Rejoindre une discussion solidaire" title section from the Home page smalltalk cards and normalizes their outer margins using standard dimension resources to match the rest of the layout items.

---
*PR created automatically by Jules for task [1716763503680802750](https://jules.google.com/task/1716763503680802750) started by @clemPerrousset*